### PR TITLE
Incorrect Exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,13 +13,8 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
-    },
-    "./cli": {
-      "types": "./dist/cli/cli.d.ts",
-      "import": "./dist/cli/cli.mjs",
-      "require": "./dist/cli/cli.js"
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
     }
   },
   "publishConfig": {


### PR DESCRIPTION
**Issue:** Cannot import the module.

**Solution:** Fixed the `exports` section in `package.json`. Output of the build is attached below. You _probably_ shouldn't have to export `cli` but feel free to revert that (note that the path is incorrect: `./dist/cli/cli.d.ts` but should be `./dist/cli.d.ts`).

<img width="185" alt="image" src="https://github.com/user-attachments/assets/1bc756a0-c2df-4895-aabb-c6929595d16e" />
