### PR TITLE
fix: use pnpm link --global for CLI installation in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,6 @@ jobs:
 
       - name: Test package installation
         run: |
-          pnpm pack
-          npm install -g ./mherod-get-cookie-*.tgz
+          pnpm run build
+          pnpm link --global
           get-cookie --help


### PR DESCRIPTION
## Summary
- Replace npm install from tarball with pnpm link --global in CI workflow
- Ensures consistent package manager usage throughout the CI pipeline

## Test plan
- [x] CI workflow should successfully link and test the CLI using pnpm
- [x] The `get-cookie --help` command should work after linking
- [x] All other CI steps continue to use pnpm consistently