### PR TITLE
ci: add Node.js version matrix to GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [20.x, 22.x, 24.x]
       fail-fast: false
 
     steps:

--- a/.github/workflows/comprehensive-tests.yml
+++ b/.github/workflows/comprehensive-tests.yml
@@ -18,6 +18,10 @@ jobs:
   advanced-tests:
     name: Run Advanced Test Scripts
     runs-on: macos-latest
+    strategy:
+      matrix:
+        node-version: [20.x, 22.x, 24.x]
+      fail-fast: false
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -27,10 +31,10 @@ jobs:
         with:
           version: 9.15.2
 
-      - name: Setup Node.js
+      - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: ${{ matrix.node-version }}
           cache: "pnpm"
 
       - name: Install dependencies
@@ -49,7 +53,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: advanced-test-results
+          name: advanced-test-results-${{ matrix.node-version }}
           path: |
             scripts/test-results/
             scripts/logs/

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -21,15 +21,17 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        node-version: [20.x]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Node
+      - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: ${{ matrix.node-version }}
 
       - uses: pnpm/action-setup@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,10 @@ jobs:
   validate-release:
     name: Validate Release
     runs-on: macos-latest
+    strategy:
+      matrix:
+        node-version: [20.x, 22.x, 24.x]
+      fail-fast: false
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -29,10 +33,10 @@ jobs:
         with:
           version: 9.15.2
 
-      - name: Setup Node.js
+      - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: ${{ matrix.node-version }}
           registry-url: "https://registry.npmjs.org"
           cache: "pnpm"
 

--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,6 @@ cookie-creator
 # CookieCreator binary
 scripts/CookieCreator/Sources/main
 scripts/CookieCreator/main
+
+# Test exports directory
+test-exports/

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "check-links": "./scripts/check-vitepress-links.sh"
   },
   "engines": {
-    "node": "^20.0.0 || ^22.0.0"
+    "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
   },
   "keywords": [],
   "author": "Matthew Herod",


### PR DESCRIPTION
## Summary
- Add Node.js version matrices to all GitHub Actions workflows to test against versions 20, 22, and 24
- Update CI pipelines to ensure compatibility across all supported Node versions

## Changes
- Updated `ci.yml` to test against Node 20, 22, and 24
- Added matrix strategy to `comprehensive-tests.yml` with all three Node versions
- Added matrix strategy to `release.yml` validation job
- Added matrix to `deploy-docs.yml` (using Node 20 only for documentation)
- Updated artifact names to include Node version for better tracking

## Test plan
- [ ] CI workflows run successfully on all Node versions
- [ ] Tests pass on Node 20, 22, and 24
- [ ] Documentation builds correctly
- [ ] Release validation works on all versions