### PR TITLE
Potential fix for code scanning alert no. 6: Incomplete string escaping or encoding

### DIFF
--- a/src/utils/patternToRegex.ts
+++ b/src/utils/patternToRegex.ts
@@ -8,14 +8,16 @@
  * stringToRegex('example.com') // returns /example\.com/
  */
 export function stringToRegex(s: string): RegExp {
+  // First, escape all backslashes
+  const s1: string = s.replace(/\\/g, "\\\\");
   // Replace all occurrences of '.' with a literal '\.'
-  const s1: string = s.replace(/\./g, "\\.");
+  const s2: string = s1.replace(/\./g, "\\.");
   // Replace all occurrences of '%' with '.*' to match any number of any characters
-  const s2: string = s1.replace(/%/g, ".*");
+  const s3: string = s2.replace(/%/g, ".*");
   // Replace all occurrences of '*' with '.*' to match any number of any characters
-  const s3: string = s2.replace(/\*/g, ".*");
+  const s4: string = s3.replace(/\*/g, ".*");
   // Return the new string as a RegExp object
-  return new RegExp(s3);
+  return new RegExp(s4);
 }
 
 /*


### PR DESCRIPTION
Potential fix for [https://github.com/mherod/get-cookie/security/code-scanning/6](https://github.com/mherod/get-cookie/security/code-scanning/6)

To correctly escape user-controlled strings for use in a RegExp, you **must** ensure that any literal backslashes in the input are themselves escaped, before any other replacements. The best solution is to first escape all backslashes in the string by replacing `\` with `\\` (using a global regex). This must be done as the *first* replacement, before handling `.` (dot), `%`, and `*`. This order ensures that subsequent replacements can't introduce new unescaped slashes or mix up escape ordering.

**How to fix:**  
- Insert a line immediately after the function's opening to replace all occurrences of `\` with `\\`.
- Rename the subsequent variables to accommodate the additional escaping step (e.g., `s1`→`s2`…).
- No external libraries are required; the fix can be performed with a simple addition using `replace(/\\/g, "\\\\")`.

**Needed:**  
- Insert a line before the other escaping steps to escape backslashes.
- Update variable names to maintain clarity and avoid naming conflicts.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
