### PR TITLE
fix(ci): resolve TypeScript Buffer type and skip Claude on Dependabot

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,6 +12,8 @@ on:
 
 jobs:
   claude-review:
+    # Skip Dependabot PRs - secrets are not accessible to Dependabot workflows
+    if: github.actor != 'dependabot[bot]'
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||

--- a/src/core/browsers/chrome/decrypt.ts
+++ b/src/core/browsers/chrome/decrypt.ts
@@ -185,7 +185,7 @@ export async function decrypt(
         decipher.setAutoPadding(false);
 
         // Decrypt the value
-        let decrypted = decipher.update(value);
+        let decrypted: Buffer = decipher.update(value);
         try {
           decipher.final();
         } catch (e) {


### PR DESCRIPTION
Fixes CI failures in PR #385 caused by dependency updates.

- Add explicit Buffer type annotation in decrypt.ts to fix type incompatibility with @types/node 24.10.1
- Skip Claude Code Review workflow on Dependabot PRs since secrets are not accessible to automated workflows

This unblocks the Dependabot dependency update PRs.