### PR TITLE
chore(release): v4.4.1 - fix Zod 4.x compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mherod/get-cookie",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "description": "Node.js module for querying cookies from Chrome, Firefox, and Safari browsers",
   "packageManager": "pnpm@9.15.2",
   "type": "module",


### PR DESCRIPTION
## Summary

- Bump version to 4.4.1
- Publish package with Zod 4.x compatible bundled code

## Details

This release fixes issue #386 where the library failed with:
```
TypeError: z.function().args is not a function
```

The root cause was that the published npm package v4.4.0 contained bundled code using the Zod 3.x API (`z.function().args()`), which was removed in Zod 4.x.

The fix was already present in the source code (commit `0a9b47c`), but the npm package needed to be republished with the updated dist.

## Test plan

- [x] Type checking passes
- [x] Linting passes
- [x] All 468 tests pass
- [x] Library loads without Zod errors
- [x] Published to npm as v4.4.1

Closes #386