### PR TITLE
Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -8,6 +8,9 @@ on:
 
 jobs:
   security-audit:
+    permissions:
+      contents: read
+      issues: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
Potential fix for [https://github.com/mherod/get-cookie/security/code-scanning/14](https://github.com/mherod/get-cookie/security/code-scanning/14)

To fix the code, we should add a `permissions` block to the workflow or to the specific job under `jobs.security-audit`. Since the only step needing write permissions is commenting on issues for pull requests, we can add `contents: read` and `issues: write` at the job level (or restrict even further by setting `permissions` for only that step if we want fine granularity). The minimal and effective solution is to add:

```yaml
permissions:
  contents: read
  issues: write
```

either at the root of the workflow (so it covers all jobs), or under the `security-audit` job. Since there is a single job, either approach yields the same effect.

Steps:
- In `.github/workflows/security-audit.yml`, above or inside the `jobs.security-audit` block (line 11), insert the `permissions` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
