### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-consolidated.yml
+++ b/.github/workflows/ci-consolidated.yml
@@ -333,6 +333,8 @@ jobs:
 
   # Final status check for branch protection
   status-check:
+    permissions:
+      contents: read
     name: CI Status
     runs-on: ubuntu-latest
     needs: [validate, docs]


### PR DESCRIPTION
Potential fix for [https://github.com/mherod/get-cookie/security/code-scanning/5](https://github.com/mherod/get-cookie/security/code-scanning/5)

To fix this problem, you should add a `permissions` block to the `status-check` job in `.github/workflows/ci-consolidated.yml`. This will restrict the GITHUB_TOKEN's available scopes for this job to only those absolutely necessary—in this case, probably none if the job only runs shell checks and does not call GitHub APIs or upload artifacts, but as a minimal best-practice starting point, use `contents: read`. Add the following under `status-check:` before `name:`:

```yaml
permissions:
  contents: read
```

This ensures the job runs with only read access to repository contents, following the principle of least privilege.

No other code changes, method definitions, or imports are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
