### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-consolidated.yml
+++ b/.github/workflows/ci-consolidated.yml
@@ -289,6 +289,8 @@ jobs:
   # Documentation build - always thorough
   docs:
     name: Build Documentation
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     needs: [changes, validate]
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/mherod/get-cookie/security/code-scanning/13](https://github.com/mherod/get-cookie/security/code-scanning/13)

To fix the problem, explicitly add a `permissions` block to the `docs` job in the workflow YAML, minimizing the GitHub token’s access. The minimal safe setting for artifact upload is typically `contents: read`, since only reading repository contents is necessary. This block should be added near the start of the `docs` job definition—just after its job identifier (just under line 291 in `.github/workflows/ci-consolidated.yml`). No other code changes or imports are needed, as artifact upload does not require broader permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
