### PR TITLE
fix(sql): throw on missing filepath in EnhancedCookieQueryService

### DIFF
--- a/src/core/browsers/sql/EnhancedCookieQueryService.ts
+++ b/src/core/browsers/sql/EnhancedCookieQueryService.ts
@@ -433,12 +433,10 @@ export class EnhancedCookieQueryService {
   private async discoverBrowserFiles(
     browser: SqlBrowserType,
   ): Promise<string[]> {
-    // This would be refactored from existing browser strategies
-    // For now, returning empty array as placeholder
-    logger.debug("Discovering files for browser", { browser });
-
-    // TODO: Integrate with existing file discovery logic
-    return [];
+    throw new Error(
+      `Auto-discovery of cookie files for "${browser}" is not yet implemented. ` +
+        `Provide an explicit "filepath" in EnhancedQueryOptions to query a specific database file.`,
+    );
   }
 
   /**

--- a/src/core/browsers/sql/__tests__/EnhancedCookieQueryService.test.ts
+++ b/src/core/browsers/sql/__tests__/EnhancedCookieQueryService.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Tests for EnhancedCookieQueryService
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  jest,
+  beforeEach,
+  afterEach,
+} from "@jest/globals";
+
+import {
+  EnhancedCookieQueryService,
+  type EnhancedQueryOptions,
+} from "../EnhancedCookieQueryService";
+import {
+  DatabaseConnectionManager,
+  resetGlobalConnectionManager,
+} from "../DatabaseConnectionManager";
+import type { SqliteDatabase } from "../adapters/DatabaseAdapter";
+
+// Mock the adapter factory so no real SQLite files are needed
+jest.mock("../adapters/DatabaseAdapter");
+
+describe("EnhancedCookieQueryService", () => {
+  let service: EnhancedCookieQueryService;
+  let mockDb: jest.Mocked<SqliteDatabase>;
+  let mockStmt: { all: jest.Mock; get: jest.Mock; run: jest.Mock };
+  let manager: DatabaseConnectionManager;
+
+  beforeEach(() => {
+    mockStmt = {
+      all: jest.fn().mockReturnValue([]),
+      get: jest.fn().mockReturnValue(undefined),
+      run: jest.fn().mockReturnValue({ changes: 0 }),
+    };
+
+    mockDb = {
+      prepare: jest.fn().mockReturnValue(mockStmt),
+      close: jest.fn(),
+      pragma: jest.fn(),
+      readonly: true,
+    } as unknown as jest.Mocked<SqliteDatabase>;
+
+    const adapterModule = require("../adapters/DatabaseAdapter");
+    (adapterModule.createSqliteDatabase as jest.Mock).mockReturnValue(mockDb);
+
+    manager = new DatabaseConnectionManager({
+      maxConnections: 2,
+      idleTimeout: 5000,
+      enableMonitoring: false,
+      retryAttempts: 1,
+    });
+
+    service = new EnhancedCookieQueryService(manager);
+  });
+
+  afterEach(() => {
+    service.shutdown();
+    resetGlobalConnectionManager();
+  });
+
+  describe("queryCookies without filepath", () => {
+    it("throws a descriptive error when no filepath is provided", async () => {
+      const options: EnhancedQueryOptions = {
+        browser: "firefox",
+        name: "%",
+        domain: "%",
+      };
+
+      await expect(service.queryCookies(options)).rejects.toThrow(
+        /Auto-discovery.*not yet implemented/,
+      );
+    });
+
+    it("throws for chrome when no filepath is provided", async () => {
+      const options: EnhancedQueryOptions = {
+        browser: "chrome",
+        name: "session",
+        domain: "example.com",
+      };
+
+      await expect(service.queryCookies(options)).rejects.toThrow(/"chrome"/);
+    });
+
+    it("error message includes instructions to provide filepath", async () => {
+      const options: EnhancedQueryOptions = {
+        browser: "edge",
+        name: "%",
+        domain: "%",
+      };
+
+      await expect(service.queryCookies(options)).rejects.toThrow(/filepath/);
+    });
+  });
+
+  describe("queryCookies with filepath", () => {
+    it("returns empty data when no rows match", async () => {
+      const options: EnhancedQueryOptions = {
+        browser: "firefox",
+        name: "test",
+        domain: "example.com",
+        filepath: "/fake/path/cookies.sqlite",
+      };
+
+      // mockStmt.all already returns []
+      const result = await service.queryCookies(options);
+
+      expect(result.data).toEqual([]);
+      expect(result.cached).toBe(false);
+    });
+
+    it("does not throw when filepath is provided even if db is empty", async () => {
+      const options: EnhancedQueryOptions = {
+        browser: "chrome",
+        name: "%",
+        domain: "%",
+        filepath: "/fake/path/Cookies",
+      };
+
+      await expect(service.queryCookies(options)).resolves.toHaveProperty(
+        "data",
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Problem

`EnhancedCookieQueryService.queryCookies()` silently returned `{ data: [] }` when no `filepath` was provided, because `discoverBrowserFiles()` was an unimplemented stub that unconditionally returned `[]`. Callers had no way to distinguish "no cookies matched" from "file discovery is broken".

## Solution

Replace the stub with a thrown `Error` that clearly names the browser and directs callers to provide an explicit `filepath` in `EnhancedQueryOptions`.

## Changes

- **`src/core/browsers/sql/EnhancedCookieQueryService.ts`**: Remove the TODO stub and `return []` from `discoverBrowserFiles()`. Throw a descriptive `Error` instead.
- **`src/core/browsers/sql/__tests__/EnhancedCookieQueryService.test.ts`**: New test file with 5 tests covering the error path (firefox, chrome, edge without filepath) and the happy path (with filepath provided).

## Verification

- [ ] `queryCookies({ browser: "firefox", name: "%", domain: "%" })` without `filepath` throws with message matching `/Auto-discovery.*not yet implemented/`
- [ ] TODO comment removed — confirmed via grep
- [ ] Unit tests added and passing (5/5)
- [ ] No regressions — 538 tests pass, 0 failures

Fixes #428