### PR TITLE
chore: release 4.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [4.4.3] - 2026-02-24
+
 ### Refactoring
 
 - Replaced three platform×browser `switch` blocks in `listProfiles()` with a

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mherod/get-cookie",
-  "version": "4.4.2",
+  "version": "4.4.3",
   "description": "Node.js module for querying cookies from Chrome, Firefox, and Safari browsers",
   "packageManager": "pnpm@9.15.2",
   "type": "module",


### PR DESCRIPTION
## Release 4.4.3

Bumps version from 4.4.2 → 4.4.3 and finalises the `[Unreleased]` changelog section.

### Changes in this release

**Refactoring**
- Replaced three platform×browser `switch` blocks in `listProfiles()` with a single data-driven lookup via `BROWSER_PATHS` (#430)
- Converted inline `require("node:fs/path/os")` calls in `cli.ts` to ESM `import` statements
- `createCompositeStrategy()` now derives the strategy list from `STRATEGY_REGISTRY` via `Object.values()` (#431)
- `BaseChromiumCookieQueryStrategy` no longer hardcodes `"chrome"` as the SQL browser type — uses `sqlBrowserType` getter with fallback (#432)

**Bug Fixes**
- `handleQueryError` now always returns a `QueryResult` and never throws (#434)
- `EnhancedCookieQueryService` now throws a clear error when `filepath` is missing (#433)