### PR TITLE
refactor(browsers): move CHROMIUM_DATA_DIRS to BrowserAvailability.ts

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 
 import { existsSync, readFileSync } from "node:fs";
-import { homedir } from "node:os";
 import { join } from "node:path";
 
 // Local imports - core
+import { CHROMIUM_DATA_DIRS } from "@core/browsers/BrowserAvailability";
 import { listChromeProfiles } from "@core/browsers/listChromeProfiles";
 import { cookieSpecsFromUrl } from "@core/cookies/cookieSpecsFromUrl";
 import { parseArgv } from "@utils/argv";
@@ -105,67 +105,6 @@ interface ChromeProfileInfo {
   user_name?: string;
   [key: string]: unknown;
 }
-
-/**
- * User data directories for Chromium-based browsers per platform.
- * Kept separate from BROWSER_PATHS (which lists all detection paths including
- * app bundles and binaries) so that profile listing always uses the correct
- * data directory regardless of how BROWSER_PATHS entries are ordered.
- */
-const CHROMIUM_DATA_DIRS: Partial<
-  Record<string, Partial<Record<string, string>>>
-> = {
-  darwin: {
-    chrome: join(
-      homedir(),
-      "Library",
-      "Application Support",
-      "Google",
-      "Chrome",
-    ),
-    edge: join(homedir(), "Library", "Application Support", "Microsoft Edge"),
-    arc: join(homedir(), "Library", "Application Support", "Arc"),
-    opera: join(
-      homedir(),
-      "Library",
-      "Application Support",
-      "com.operasoftware.Opera",
-    ),
-    "opera-gx": join(
-      homedir(),
-      "Library",
-      "Application Support",
-      "com.operasoftware.OperaGX",
-    ),
-  },
-  win32: {
-    // Chrome and Edge store profiles under …\User Data on Windows
-    chrome: join(
-      process.env.LOCALAPPDATA ?? "",
-      "Google",
-      "Chrome",
-      "User Data",
-    ),
-    edge: join(
-      process.env.LOCALAPPDATA ?? "",
-      "Microsoft",
-      "Edge",
-      "User Data",
-    ),
-    opera: join(process.env.APPDATA ?? "", "Opera Software", "Opera Stable"),
-    "opera-gx": join(
-      process.env.APPDATA ?? "",
-      "Opera Software",
-      "Opera GX Stable",
-    ),
-  },
-  linux: {
-    chrome: join(homedir(), ".config", "google-chrome"),
-    edge: join(homedir(), ".config", "microsoft-edge"),
-    opera: join(homedir(), ".config", "opera"),
-    "opera-gx": join(homedir(), ".config", "opera-gx"),
-  },
-};
 
 /**
  * Resolves the user data directory for a Chromium-based browser on the current platform.

--- a/src/core/browsers/BrowserAvailability.ts
+++ b/src/core/browsers/BrowserAvailability.ts
@@ -123,6 +123,67 @@ export const BROWSER_PATHS = {
 };
 
 /**
+ * User data directories for Chromium-based browsers per platform.
+ * Kept separate from BROWSER_PATHS (which lists all detection paths including
+ * app bundles and binaries) so that profile listing always uses the correct
+ * data directory regardless of how BROWSER_PATHS entries are ordered.
+ */
+export const CHROMIUM_DATA_DIRS: Partial<
+  Record<string, Partial<Record<string, string>>>
+> = {
+  darwin: {
+    chrome: join(
+      homedir(),
+      "Library",
+      "Application Support",
+      "Google",
+      "Chrome",
+    ),
+    edge: join(homedir(), "Library", "Application Support", "Microsoft Edge"),
+    arc: join(homedir(), "Library", "Application Support", "Arc"),
+    opera: join(
+      homedir(),
+      "Library",
+      "Application Support",
+      "com.operasoftware.Opera",
+    ),
+    "opera-gx": join(
+      homedir(),
+      "Library",
+      "Application Support",
+      "com.operasoftware.OperaGX",
+    ),
+  },
+  win32: {
+    // Chrome and Edge store profiles under …\User Data on Windows
+    chrome: join(
+      process.env.LOCALAPPDATA ?? "",
+      "Google",
+      "Chrome",
+      "User Data",
+    ),
+    edge: join(
+      process.env.LOCALAPPDATA ?? "",
+      "Microsoft",
+      "Edge",
+      "User Data",
+    ),
+    opera: join(process.env.APPDATA ?? "", "Opera Software", "Opera Stable"),
+    "opera-gx": join(
+      process.env.APPDATA ?? "",
+      "Opera Software",
+      "Opera GX Stable",
+    ),
+  },
+  linux: {
+    chrome: join(homedir(), ".config", "google-chrome"),
+    edge: join(homedir(), ".config", "microsoft-edge"),
+    opera: join(homedir(), ".config", "opera"),
+    "opera-gx": join(homedir(), ".config", "opera-gx"),
+  },
+};
+
+/**
  * Checks if a browser is installed by looking for its paths
  * @param browser - The browser type to check
  * @returns True if the browser is installed

--- a/src/core/browsers/__tests__/BrowserAvailability.test.ts
+++ b/src/core/browsers/__tests__/BrowserAvailability.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Tests for BrowserAvailability exports
+ */
+
+import { describe, it, expect } from "@jest/globals";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import { CHROMIUM_DATA_DIRS } from "../BrowserAvailability";
+
+describe("CHROMIUM_DATA_DIRS", () => {
+  it("has entries for darwin, win32, and linux", () => {
+    expect(CHROMIUM_DATA_DIRS).toHaveProperty("darwin");
+    expect(CHROMIUM_DATA_DIRS).toHaveProperty("win32");
+    expect(CHROMIUM_DATA_DIRS).toHaveProperty("linux");
+  });
+
+  describe("darwin paths", () => {
+    const darwin = CHROMIUM_DATA_DIRS["darwin"];
+
+    it("has a chrome entry", () => {
+      expect(typeof darwin?.["chrome"]).toBe("string");
+    });
+
+    it("chrome path points to Google/Chrome under Application Support", () => {
+      expect(darwin?.["chrome"]).toBe(
+        join(homedir(), "Library", "Application Support", "Google", "Chrome"),
+      );
+    });
+
+    it("has edge, arc, opera, and opera-gx entries", () => {
+      expect(typeof darwin?.["edge"]).toBe("string");
+      expect(typeof darwin?.["arc"]).toBe("string");
+      expect(typeof darwin?.["opera"]).toBe("string");
+      expect(typeof darwin?.["opera-gx"]).toBe("string");
+    });
+
+    it("opera-gx path uses com.operasoftware.OperaGX bundle", () => {
+      expect(darwin?.["opera-gx"]).toContain("com.operasoftware.OperaGX");
+    });
+  });
+
+  describe("win32 paths", () => {
+    const win32 = CHROMIUM_DATA_DIRS["win32"];
+
+    it("has chrome, edge, opera, and opera-gx entries", () => {
+      expect(typeof win32?.["chrome"]).toBe("string");
+      expect(typeof win32?.["edge"]).toBe("string");
+      expect(typeof win32?.["opera"]).toBe("string");
+      expect(typeof win32?.["opera-gx"]).toBe("string");
+    });
+
+    it("chrome path includes User Data suffix", () => {
+      expect(win32?.["chrome"]).toContain("User Data");
+    });
+
+    it("edge path includes User Data suffix", () => {
+      expect(win32?.["edge"]).toContain("User Data");
+    });
+  });
+
+  describe("linux paths", () => {
+    const linux = CHROMIUM_DATA_DIRS["linux"];
+
+    it("has chrome, edge, opera, and opera-gx entries", () => {
+      expect(typeof linux?.["chrome"]).toBe("string");
+      expect(typeof linux?.["edge"]).toBe("string");
+      expect(typeof linux?.["opera"]).toBe("string");
+      expect(typeof linux?.["opera-gx"]).toBe("string");
+    });
+
+    it("chrome path is under .config/google-chrome", () => {
+      expect(linux?.["chrome"]).toBe(
+        join(homedir(), ".config", "google-chrome"),
+      );
+    });
+
+    it("edge path is under .config/microsoft-edge", () => {
+      expect(linux?.["edge"]).toBe(
+        join(homedir(), ".config", "microsoft-edge"),
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Moves `CHROMIUM_DATA_DIRS` from `src/cli/cli.ts` (private constant) to `src/core/browsers/BrowserAvailability.ts` (exported), making it reusable by any module that needs Chromium data-directory paths
- Removes inline `node:os homedir` import from `cli.ts`; `getChromiumDataDir()` helper stays in `cli.ts` as a thin wrapper over the imported constant
- Adds 11 unit tests in `BrowserAvailability.test.ts` covering darwin, win32, and linux path shapes

## Test plan

- [x] `pnpm type-check` — no errors
- [x] `pnpm lint` — 213 files, no errors
- [x] `pnpm test` — 536 passed, 0 failures (11 new tests in BrowserAvailability.test.ts)

Fixes #441