### PR TITLE
chore: exclude .swiz cache directory from Biome checks

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -15,7 +15,8 @@
       "!**/coverage/**",
       "!**/docs/.vitepress/cache/**",
       "!**/*.log",
-      "!**/.parcel-cache/**"
+      "!**/.parcel-cache/**",
+      "!**/.swiz/**"
     ]
   },
   "formatter": {


### PR DESCRIPTION
## Summary
- Add `!**/.swiz/**` to `biome.json` `files.includes` to exclude `.swiz/` cache files from Biome formatting checks
- These are auto-generated cache files (already gitignored) that get rewritten as single-line JSON by tooling, causing persistent Biome formatting violations

## Test plan
- [x] `pnpm run lint` passes (213 files checked, 0 errors)
- [x] All pre-push hooks pass (type-check, lint, 536 tests, link checks, format check)