### PR TITLE
chore(sql): remove stale TODO comments from getFilepaths

### DIFF
--- a/src/core/browsers/sql/EnhancedCookieQueryService.ts
+++ b/src/core/browsers/sql/EnhancedCookieQueryService.ts
@@ -426,8 +426,6 @@ export class EnhancedCookieQueryService {
       return [options.filepath];
     }
 
-    // Import browser-specific file discovery logic
-    // This would be refactored from existing code
     return this.discoverBrowserFiles(options.browser);
   }
 


### PR DESCRIPTION
## Summary

- Removes two stale comments in `getFilepaths()` that referenced future refactoring completed in PR #452

## Test plan

- [x] No behavior change — comment-only removal
- [x] All 570 tests pass locally