### PR TITLE
fix(cli): add brave to profile listing

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -126,6 +126,7 @@ function listProfiles(browser?: string): void {
     browserLower === "chrome" ||
     browserLower === "edge" ||
     browserLower === "arc" ||
+    browserLower === "brave" ||
     browserLower === "opera" ||
     browserLower === "opera-gx"
   ) {


### PR DESCRIPTION
## Summary
- Add `brave` to the Chromium browser condition in `listProfiles()` so that `get-cookie --browser brave --list-profiles` correctly enumerates Brave profiles via the `Local State` file, matching the existing behavior for chrome, edge, arc, opera, and opera-gx.

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] All 574 tests pass (pre-push hook)