### PR TITLE
refactor(cli): derive chromium check from data

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -121,15 +121,9 @@ function listProfiles(browser?: string): void {
   }
 
   const browserLower = browser.toLowerCase();
+  const dataDir = getChromiumDataDir(browserLower);
 
-  if (
-    browserLower === "chrome" ||
-    browserLower === "edge" ||
-    browserLower === "arc" ||
-    browserLower === "brave" ||
-    browserLower === "opera" ||
-    browserLower === "opera-gx"
-  ) {
+  if (dataDir) {
     try {
       const profiles = listChromeProfiles();
 
@@ -140,13 +134,6 @@ function listProfiles(browser?: string): void {
 
       logger.log(`${browser} profiles:`);
       logger.log("");
-
-      const dataDir = getChromiumDataDir(browserLower);
-
-      if (!dataDir) {
-        logger.error(`Unsupported browser for profile listing: ${browser}`);
-        return;
-      }
 
       const localStatePath = join(dataDir, "Local State");
 


### PR DESCRIPTION
## Summary
- Replace hardcoded 6-browser condition in `listProfiles()` with a `getChromiumDataDir()` lookup against `CHROMIUM_DATA_DIRS`. Adding a new Chromium browser to the data map now automatically enables `--list-profiles` support — no CLI code change needed.

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes  
- [x] All 574 tests pass (pre-push hook)