### PR TITLE
feat(browsers): add profile filtering to all Chromium browsers

### DIFF
--- a/src/core/browsers/StrategyFactory.ts
+++ b/src/core/browsers/StrategyFactory.ts
@@ -57,14 +57,19 @@ const STRATEGY_REGISTRY: Record<BrowserType, StrategyConstructor> = {
  * with validation and graceful fallback, use createStrategy() instead.
  *
  * @param browser - The browser to create a strategy for (must be a valid BrowserType)
+ * @param profile - Optional profile name to target (supported by Chromium-based browsers)
  * @returns A cookie query strategy for the specified browser
  * @throws {Error} if browser is not in STRATEGY_REGISTRY (should not happen with valid BrowserType)
  */
 export function createBrowserStrategy(
   browser: BrowserType,
+  profile?: string,
 ): BaseCookieQueryStrategy {
   const Strategy = STRATEGY_REGISTRY[browser];
-  logger.debug("Creating browser strategy", { browser });
+  logger.debug("Creating browser strategy", { browser, profile });
+  if (profile !== undefined) {
+    return new Strategy(profile);
+  }
   return new Strategy();
 }
 
@@ -104,26 +109,11 @@ export function createSelectiveCompositeStrategy(
 }
 
 /**
- * Creates a Chrome strategy with profile if specified
- * @param profile - Optional browser profile name
- * @returns Chrome cookie query strategy
- */
-function createChromeStrategyWithProfile(
-  profile: string | undefined,
-): BaseCookieQueryStrategy {
-  if (profile !== undefined) {
-    logger.debug("Creating Chrome strategy with profile", { profile });
-    return new ChromeCookieQueryStrategy(profile);
-  }
-  return new ChromeCookieQueryStrategy();
-}
-
-/**
  * Creates a strategy based on browser type or store path
  * @param options - Options for strategy creation
  * @param options.browser - Optional browser type
  * @param options.storePath - Optional path to a cookie store file
- * @param options.profile - Optional browser profile name
+ * @param options.profile - Optional browser profile name (supported by all Chromium-based browsers)
  * @returns A cookie query strategy
  */
 export function createStrategy(options?: {
@@ -149,11 +139,7 @@ export function createStrategy(options?: {
   if (browser !== undefined) {
     const normalizedBrowser = browser.toLowerCase();
     if (isValidBrowserType(normalizedBrowser)) {
-      // Special handling for Chrome with profile
-      if (normalizedBrowser === "chrome") {
-        return createChromeStrategyWithProfile(profile);
-      }
-      return createBrowserStrategy(normalizedBrowser);
+      return createBrowserStrategy(normalizedBrowser, profile);
     }
     // Invalid browser type: log warning and fall back to composite strategy
     // This provides graceful degradation when users pass invalid browser strings

--- a/src/core/browsers/arc/ArcCookieQueryStrategy.ts
+++ b/src/core/browsers/arc/ArcCookieQueryStrategy.ts
@@ -3,6 +3,7 @@ import { ChromiumCookieQueryStrategy } from "../chromium/ChromiumCookieQueryStra
 /**
  * Strategy for querying cookies from Arc browser.
  * Arc is a Chromium-based browser with unique features but standard cookie storage.
+ * Supports optional profile-name filtering via the profileName constructor parameter.
  * @example
  * ```typescript
  * const strategy = new ArcCookieQueryStrategy();
@@ -12,8 +13,9 @@ import { ChromiumCookieQueryStrategy } from "../chromium/ChromiumCookieQueryStra
 export class ArcCookieQueryStrategy extends ChromiumCookieQueryStrategy {
   /**
    * Creates a new instance of ArcCookieQueryStrategy
+   * @param profileName - Optional specific profile name to target
    */
-  public constructor() {
-    super("arc");
+  public constructor(profileName?: string) {
+    super("arc", profileName);
   }
 }

--- a/src/core/browsers/brave/BraveCookieQueryStrategy.ts
+++ b/src/core/browsers/brave/BraveCookieQueryStrategy.ts
@@ -3,6 +3,7 @@ import { ChromiumCookieQueryStrategy } from "../chromium/ChromiumCookieQueryStra
 /**
  * Strategy for querying cookies from Brave browser.
  * Brave is a Chromium-based browser with standard cookie storage.
+ * Supports optional profile-name filtering via the profileName constructor parameter.
  * @example
  * ```typescript
  * const strategy = new BraveCookieQueryStrategy();
@@ -12,8 +13,9 @@ import { ChromiumCookieQueryStrategy } from "../chromium/ChromiumCookieQueryStra
 export class BraveCookieQueryStrategy extends ChromiumCookieQueryStrategy {
   /**
    * Creates a new instance of BraveCookieQueryStrategy
+   * @param profileName - Optional specific profile name to target
    */
-  public constructor() {
-    super("brave");
+  public constructor(profileName?: string) {
+    super("brave", profileName);
   }
 }

--- a/src/core/browsers/chrome/ChromeCookieQueryStrategy.ts
+++ b/src/core/browsers/chrome/ChromeCookieQueryStrategy.ts
@@ -1,129 +1,25 @@
-import { existsSync, readFileSync } from "node:fs";
-import { dirname, join } from "node:path";
-
 import { ChromiumCookieQueryStrategy } from "../chromium/ChromiumCookieQueryStrategy";
 
 /**
- * Interface representing Chrome profile information from Local State
- */
-interface ChromeProfileInfo {
-  name?: string;
-  user_name?: string;
-  [key: string]: unknown;
-}
-
-/**
  * Strategy for querying cookies from Chrome browser.
- * This class extends the ChromiumCookieQueryStrategy with Chrome-specific
- * profile-name filtering logic.
+ * Extends ChromiumCookieQueryStrategy with Chrome as the target browser.
+ * Supports optional profile-name filtering via the profileName constructor parameter.
  * @example
  * ```typescript
  * const strategy = new ChromeCookieQueryStrategy();
  * const cookies = await strategy.queryCookies('session', 'example.com');
+ *
+ * // With profile filtering
+ * const strategy = new ChromeCookieQueryStrategy('Work');
+ * const cookies = await strategy.queryCookies('session', 'example.com');
  * ```
  */
 export class ChromeCookieQueryStrategy extends ChromiumCookieQueryStrategy {
-  private readonly profileName?: string;
-
   /**
    * Creates a new instance of ChromeCookieQueryStrategy
    * @param profileName - Optional specific profile name to target
    */
   public constructor(profileName?: string) {
-    super("chrome");
-    if (profileName !== undefined) {
-      this.profileName = profileName;
-    }
-  }
-
-  /**
-   * Get Chrome-specific cookie file paths, with optional profile filtering
-   * @param store - Optional specific store path
-   * @returns Array of cookie file paths
-   */
-  protected override getCookieFilePaths(store?: string): string[] {
-    let paths = super.getCookieFilePaths(store);
-
-    // If a store was provided or no profile filter, return as-is
-    if ((store !== undefined && store !== "") || !this.profileName) {
-      return paths;
-    }
-
-    // Filter by profile name if specified
-    try {
-      // Ensure we have at least one path to determine the Chrome data directory
-      if (paths.length === 0) {
-        this.logger.warn("No Chrome cookie files found");
-        return [];
-      }
-
-      const firstPath = paths[0];
-      if (!firstPath) {
-        return [];
-      }
-      const chromeDataDir = dirname(dirname(firstPath)); // Get Chrome data directory
-      const localStatePath = join(chromeDataDir, "Local State");
-
-      if (existsSync(localStatePath)) {
-        const localState = JSON.parse(readFileSync(localStatePath, "utf8"));
-        const profileCache = localState.profile?.info_cache || {};
-
-        // Find the directory for the given profile name
-        let targetDir: string | undefined;
-
-        for (const [dir, info] of Object.entries(profileCache)) {
-          const profile = info as ChromeProfileInfo;
-          if (profile.name?.toLowerCase() === this.profileName.toLowerCase()) {
-            targetDir = dir;
-            break;
-          }
-        }
-
-        // Also check if user passed the directory name directly (e.g., "Default" or "Profile 2")
-        if (!targetDir) {
-          for (const dir of Object.keys(profileCache)) {
-            if (dir.toLowerCase() === this.profileName.toLowerCase()) {
-              targetDir = dir;
-              break;
-            }
-          }
-        }
-
-        if (targetDir) {
-          // Filter paths to only include the target directory
-          paths = paths.filter((cookiePath) => {
-            const dir = dirname(cookiePath);
-            return dir.endsWith(targetDir);
-          });
-
-          if (paths.length === 0) {
-            this.logger.warn(
-              `No cookie files found for profile: ${this.profileName} (directory: ${targetDir})`,
-            );
-          } else {
-            this.logger.debug(
-              `Found ${paths.length} cookie file(s) for profile: ${this.profileName}`,
-            );
-          }
-        } else {
-          this.logger.debug("Profile not found in Chrome Local State", {
-            requestedProfile: this.profileName,
-            availableProfiles: Object.entries(profileCache).map(
-              ([dir, info]) => ({
-                directory: dir,
-                name: (info as ChromeProfileInfo).name,
-              }),
-            ),
-          });
-
-          // Return empty array to avoid querying wrong profile
-          return [];
-        }
-      }
-    } catch (error) {
-      this.logger.warn(`Failed to read Chrome profile info: ${error}`);
-    }
-
-    return Array.isArray(paths) ? paths : [paths];
+    super("chrome", profileName);
   }
 }

--- a/src/core/browsers/chromium/ChromiumCookieQueryStrategy.ts
+++ b/src/core/browsers/chromium/ChromiumCookieQueryStrategy.ts
@@ -1,3 +1,6 @@
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
 import fg from "fast-glob";
 
 import {
@@ -8,29 +11,51 @@ import {
 import { BaseChromiumCookieQueryStrategy } from "./BaseChromiumCookieQueryStrategy";
 
 /**
+ * Profile information from a Chromium browser's Local State file
+ */
+interface ChromiumProfileInfo {
+  name?: string;
+  user_name?: string;
+  [key: string]: unknown;
+}
+
+/**
  * Strategy for querying cookies from Chromium-based browsers (Chrome, Brave, Edge, etc.)
- * This class extends the BaseChromiumCookieQueryStrategy with browser-specific path discovery.
+ * This class extends the BaseChromiumCookieQueryStrategy with browser-specific path discovery
+ * and optional profile-name filtering.
  * @example
  * ```typescript
  * const strategy = new ChromiumCookieQueryStrategy('brave');
+ * const cookies = await strategy.queryCookies('session', 'example.com');
+ *
+ * // With profile filtering
+ * const strategy = new ChromiumCookieQueryStrategy('chrome', 'Work');
  * const cookies = await strategy.queryCookies('session', 'example.com');
  * ```
  */
 export class ChromiumCookieQueryStrategy extends BaseChromiumCookieQueryStrategy {
   private readonly browser: ChromiumBrowser;
+  private readonly profileName?: string;
 
   /**
    * Creates a new instance of ChromiumCookieQueryStrategy
    * @param browser - The Chromium-based browser to query (chrome, brave, edge, etc.)
+   * @param profileName - Optional specific profile name to target
    */
-  public constructor(browser: ChromiumBrowser = "chrome") {
+  public constructor(
+    browser: ChromiumBrowser = "chrome",
+    profileName?: string,
+  ) {
     const browserName = browser.charAt(0).toUpperCase() + browser.slice(1);
     super(`${browserName}CookieQueryStrategy`, browserName, browser);
     this.browser = browser;
+    if (profileName !== undefined) {
+      this.profileName = profileName;
+    }
   }
 
   /**
-   * Get browser-specific cookie file paths
+   * Get browser-specific cookie file paths, with optional profile filtering
    * @param store - Optional specific store path
    * @returns Array of cookie file paths
    */
@@ -39,23 +64,114 @@ export class ChromiumCookieQueryStrategy extends BaseChromiumCookieQueryStrategy
       return [store];
     }
 
+    let paths: string[];
+
     try {
       const browserPath = getChromiumBrowserPath(this.browser);
-      const files = fg.sync("./**/Cookies", {
+      paths = fg.sync("./**/Cookies", {
         cwd: browserPath,
         absolute: true,
       });
 
       this.logger.debug(
-        `Found ${files.length} cookie files for ${this.browser}`,
+        `Found ${paths.length} cookie files for ${this.browser}`,
       );
-
-      return files;
     } catch (error) {
       this.logger.warn(`Failed to find ${this.browser} cookie files`, {
         error: this.getErrorMessage(error),
       });
       return [];
+    }
+
+    // If no profile filter, return all paths
+    if (!this.profileName) {
+      return paths;
+    }
+
+    // Filter by profile name
+    return this.filterByProfileName(paths);
+  }
+
+  /**
+   * Filter cookie file paths to only include those matching the target profile name.
+   * Reads the browser's Local State file to map profile display names to directories.
+   * @param paths - Array of cookie file paths to filter
+   * @returns Filtered array of cookie file paths
+   */
+  private filterByProfileName(paths: string[]): string[] {
+    try {
+      if (paths.length === 0) {
+        this.logger.warn(`No ${this.browser} cookie files found`);
+        return [];
+      }
+
+      const firstPath = paths[0];
+      if (!firstPath) {
+        return [];
+      }
+      const dataDir = dirname(dirname(firstPath));
+      const localStatePath = join(dataDir, "Local State");
+
+      if (!existsSync(localStatePath)) {
+        return paths;
+      }
+
+      const localState = JSON.parse(readFileSync(localStatePath, "utf8"));
+      const profileCache = localState.profile?.info_cache || {};
+
+      // Find the directory for the given profile name
+      let targetDir: string | undefined;
+
+      for (const [dir, info] of Object.entries(profileCache)) {
+        const profile = info as ChromiumProfileInfo;
+        if (profile.name?.toLowerCase() === this.profileName?.toLowerCase()) {
+          targetDir = dir;
+          break;
+        }
+      }
+
+      // Also check if user passed the directory name directly (e.g., "Default" or "Profile 2")
+      if (!targetDir) {
+        for (const dir of Object.keys(profileCache)) {
+          if (dir.toLowerCase() === this.profileName?.toLowerCase()) {
+            targetDir = dir;
+            break;
+          }
+        }
+      }
+
+      if (targetDir) {
+        const filtered = paths.filter((cookiePath) => {
+          const dir = dirname(cookiePath);
+          return dir.endsWith(targetDir);
+        });
+
+        if (filtered.length === 0) {
+          this.logger.warn(
+            `No cookie files found for profile: ${this.profileName} (directory: ${targetDir})`,
+          );
+        } else {
+          this.logger.debug(
+            `Found ${filtered.length} cookie file(s) for profile: ${this.profileName}`,
+          );
+        }
+
+        return filtered;
+      }
+
+      this.logger.debug(`Profile not found in ${this.browser} Local State`, {
+        requestedProfile: this.profileName,
+        availableProfiles: Object.entries(profileCache).map(([dir, info]) => ({
+          directory: dir,
+          name: (info as ChromiumProfileInfo).name,
+        })),
+      });
+
+      // Return empty array to avoid querying wrong profile
+      return [];
+    } catch (error) {
+      this.logger.warn(`Failed to read ${this.browser} profile info: ${error}`);
+      return paths;
     }
   }
 }

--- a/src/core/browsers/edge/EdgeCookieQueryStrategy.ts
+++ b/src/core/browsers/edge/EdgeCookieQueryStrategy.ts
@@ -3,6 +3,7 @@ import { ChromiumCookieQueryStrategy } from "../chromium/ChromiumCookieQueryStra
 /**
  * Strategy for querying cookies from Microsoft Edge browser.
  * Edge is Chromium-based and uses the same cookie storage format as Chrome.
+ * Supports optional profile-name filtering via the profileName constructor parameter.
  * @example
  * ```typescript
  * const strategy = new EdgeCookieQueryStrategy();
@@ -12,8 +13,9 @@ import { ChromiumCookieQueryStrategy } from "../chromium/ChromiumCookieQueryStra
 export class EdgeCookieQueryStrategy extends ChromiumCookieQueryStrategy {
   /**
    * Creates a new instance of EdgeCookieQueryStrategy
+   * @param profileName - Optional specific profile name to target
    */
-  public constructor() {
-    super("edge");
+  public constructor(profileName?: string) {
+    super("edge", profileName);
   }
 }

--- a/src/core/browsers/opera/OperaCookieQueryStrategy.ts
+++ b/src/core/browsers/opera/OperaCookieQueryStrategy.ts
@@ -3,6 +3,7 @@ import { ChromiumCookieQueryStrategy } from "../chromium/ChromiumCookieQueryStra
 /**
  * Strategy for querying cookies from Opera browser.
  * Opera is a Chromium-based browser with its own keychain entry.
+ * Supports optional profile-name filtering via the profileName constructor parameter.
  * @example
  * ```typescript
  * const strategy = new OperaCookieQueryStrategy();
@@ -12,8 +13,9 @@ import { ChromiumCookieQueryStrategy } from "../chromium/ChromiumCookieQueryStra
 export class OperaCookieQueryStrategy extends ChromiumCookieQueryStrategy {
   /**
    * Creates a new instance of OperaCookieQueryStrategy
+   * @param profileName - Optional specific profile name to target
    */
-  public constructor() {
-    super("opera");
+  public constructor(profileName?: string) {
+    super("opera", profileName);
   }
 }

--- a/src/core/browsers/opera/OperaGXCookieQueryStrategy.ts
+++ b/src/core/browsers/opera/OperaGXCookieQueryStrategy.ts
@@ -3,6 +3,7 @@ import { ChromiumCookieQueryStrategy } from "../chromium/ChromiumCookieQueryStra
 /**
  * Strategy for querying cookies from Opera GX browser.
  * Opera GX is the gaming-focused variant of Opera, sharing the same keychain entry.
+ * Supports optional profile-name filtering via the profileName constructor parameter.
  * @example
  * ```typescript
  * const strategy = new OperaGXCookieQueryStrategy();
@@ -12,8 +13,9 @@ import { ChromiumCookieQueryStrategy } from "../chromium/ChromiumCookieQueryStra
 export class OperaGXCookieQueryStrategy extends ChromiumCookieQueryStrategy {
   /**
    * Creates a new instance of OperaGXCookieQueryStrategy
+   * @param profileName - Optional specific profile name to target
    */
-  public constructor() {
-    super("opera-gx");
+  public constructor(profileName?: string) {
+    super("opera-gx", profileName);
   }
 }


### PR DESCRIPTION
## Summary

- Lifts profile-name filtering from `ChromeCookieQueryStrategy` into `ChromiumCookieQueryStrategy`, so **all Chromium browsers** (Brave, Edge, Arc, Opera, OperaGX) now support `--profile`.
- Previously only Chrome honoured `--profile`; other Chromium browsers silently ignored it.
- `StrategyFactory.createBrowserStrategy()` now passes `profile` to all browsers, removing the Chrome-only `createChromeStrategyWithProfile` helper.
- `ChromeCookieQueryStrategy` is now a thin subclass (`super("chrome", profileName)`) with no override.

## Test plan

- [x] `pnpm run type-check` passes
- [x] `pnpm run lint` passes
- [x] All 573 tests pass (69 suites)
- [x] Existing Chrome profile-filtering tests continue to pass (mocking `fast-glob` + `ChromiumBrowsers`)