### PR TITLE
fix(safari): warn when --profile is used

### DIFF
--- a/src/core/browsers/safari/SafariCookieQueryStrategy.ts
+++ b/src/core/browsers/safari/SafariCookieQueryStrategy.ts
@@ -25,10 +25,16 @@ export class SafariCookieQueryStrategy extends BaseCookieQueryStrategy {
 
   /**
    * Creates a new instance of SafariCookieQueryStrategy
+   * @param profileName - Ignored; Safari does not support profile filtering
    */
-  public constructor() {
+  public constructor(profileName?: string) {
     super("SafariCookieQueryStrategy", "Safari");
     this.lockHandler = new BrowserLockHandler(this.logger, "Safari");
+    if (profileName !== undefined) {
+      this.logger.warn(
+        `Safari does not support profile filtering (--profile "${profileName}" will be ignored)`,
+      );
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

- Safari does not support profile filtering — it uses the system keychain for the current user
- When `--profile` is passed with `--browser safari`, a `logger.warn` now surfaces an actionable message instead of silently returning empty results
- Safari constructor now accepts the optional `profileName` parameter (matching `StrategyConstructor` type) but only uses it for the warning

## Test plan

- [x] `pnpm type-check` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` — 573/573 tests pass, 69/69 suites
- [ ] CI checks pass