### PR TITLE
fix(firefox): warn when profile name has no match

### DIFF
--- a/src/core/browsers/firefox/FirefoxCookieQueryStrategy.ts
+++ b/src/core/browsers/firefox/FirefoxCookieQueryStrategy.ts
@@ -269,10 +269,25 @@ function filterByFirefoxProfile(
   }
 
   if (matchingDirNames.size === 0) {
-    logger.debug("Firefox profile not found in profiles.ini", {
-      requestedProfile: profileName,
-      checked: profileDirs,
-    });
+    // Collect all known profile names for an actionable suggestion
+    const knownNames = new Set<string>();
+    for (const dataDir of profileDirs) {
+      const iniPath = join(dataDir, "profiles.ini");
+      if (!existsSync(iniPath)) {
+        continue;
+      }
+      for (const p of parseFirefoxProfilesIni(iniPath)) {
+        knownNames.add(p.name);
+      }
+    }
+
+    const available =
+      knownNames.size > 0
+        ? ` Available profiles: ${[...knownNames].join(", ")}`
+        : "";
+    logger.warn(
+      `No Firefox profile matching "${profileName}" found.${available}`,
+    );
     return [];
   }
 


### PR DESCRIPTION
## Summary
- When `--profile` specifies a name not found in Firefox's `profiles.ini`, the strategy now logs a `logger.warn` with the unrecognised name and lists available profile names
- Parallels the Safari warning added in PR #463 — users get actionable feedback instead of silent empty results

## Test plan
- [x] `pnpm type-check` passes
- [x] `pnpm lint` passes
- [x] Firefox test suites pass (3/3 active, 2 platform-skipped)
- [x] Pre-push hooks pass (full validate suite)