### PR TITLE
fix(chromium): warn when profile name has no match

### DIFF
--- a/src/core/browsers/chromium/ChromiumCookieQueryStrategy.ts
+++ b/src/core/browsers/chromium/ChromiumCookieQueryStrategy.ts
@@ -159,13 +159,16 @@ export class ChromiumCookieQueryStrategy extends BaseChromiumCookieQueryStrategy
         return filtered;
       }
 
-      this.logger.debug(`Profile not found in ${this.browser} Local State`, {
-        requestedProfile: this.profileName,
-        availableProfiles: Object.entries(profileCache).map(([dir, info]) => ({
-          directory: dir,
-          name: (info as ChromiumProfileInfo).name,
-        })),
-      });
+      const availableNames = Object.entries(profileCache)
+        .map(([, info]) => (info as ChromiumProfileInfo).name)
+        .filter(Boolean);
+      const available =
+        availableNames.length > 0
+          ? ` Available profiles: ${availableNames.join(", ")}`
+          : "";
+      this.logger.warn(
+        `No ${this.browser} profile matching "${this.profileName}" found.${available}`,
+      );
 
       // Return empty array to avoid querying wrong profile
       return [];


### PR DESCRIPTION
## Summary
- Escalates profile mismatch logging from `debug` to `warn` in `ChromiumCookieQueryStrategy.filterByProfileName()`
- Lists available profile names in the warning so users can correct typos
- Single fix covers all 6 Chromium browsers: Chrome, Edge, Brave, Arc, Opera, OperaGX
- Completes the profile-mismatch warning pattern alongside Firefox (PR #464) and Safari (PR #465)

## Test plan
- [x] `pnpm type-check` passes
- [x] `pnpm lint` passes
- [x] StrategyFactory tests pass (31 tests)
- [x] Pre-push hooks pass (full validate suite)