### PR TITLE
chore(ci): remove Swift CodeQL analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,7 +27,7 @@ jobs:
     #   - https://gh.io/supported-runners-and-hardware-resources
     #   - https://gh.io/using-larger-runners (GitHub.com only)
     # Consider using larger runners or machines with greater resources for possible analysis time improvements.
-    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     permissions:
       # required for all workflows
       security-events: write
@@ -47,9 +47,7 @@ jobs:
           build-mode: none
         - language: javascript-typescript
           build-mode: none
-        - language: swift
-          build-mode: autobuild
-        # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'
+        # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust'
         # Use `c-cpp` to analyze code written in C, C++ or both
         # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
         # Use 'javascript-typescript' to analyze code written in JavaScript, TypeScript or both

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,9 +175,6 @@ a stale global link exists. Remove it with `pnpm remove --global <package-name>`
 
 - **Required / authoritative**: Validate (all matrix entries), CI Status, Advanced Tests,
   Build Documentation, CodeQL JS, `claude-review`
-- **Known slow**: `Analyze (swift)` — the Swift CodeQL job consistently takes 2–5 minutes.
-  DO NOT watch it with `gh run watch`. Poll with `gh run list --branch main` or wait for
-  the background task notification.
 - **Pre-existing infrastructure noise**: `Release to npm` OIDC failures when publishing
   was already completed manually.
 


### PR DESCRIPTION
Closes #467

## Summary
- Removes `Analyze (swift)` job from CodeQL Advanced workflow
- Simplifies runner selection from conditional `macos-latest`/`ubuntu-latest` to just `ubuntu-latest`
- Removes "Known slow" Swift CI note from CLAUDE.md

Only 2 Swift files exist in the repo (`scripts/CookieCreator/`), a helper script that can be QA'd locally. The Swift job consistently took 2-5 minutes on `macos-latest` and was the slowest CI check blocking PR auto-merges.

## Test plan
- [x] `pnpm type-check` passes
- [x] `pnpm lint` passes
- [x] Pre-push hooks pass
- [ ] CI passes without the Swift analysis job (verify after merge)