### PR TITLE
feat(browsers): add Vivaldi browser support

### DIFF
--- a/src/core/browsers/BrowserAvailability.ts
+++ b/src/core/browsers/BrowserAvailability.ts
@@ -72,6 +72,11 @@ export const BROWSER_PATHS = {
       `${homedir()}/Applications/Brave Browser.app`,
       `${homedir()}/Library/Application Support/BraveSoftware/Brave-Browser`,
     ],
+    vivaldi: [
+      "/Applications/Vivaldi.app",
+      `${homedir()}/Applications/Vivaldi.app`,
+      `${homedir()}/Library/Application Support/Vivaldi`,
+    ],
   },
   win32: {
     chrome: [
@@ -105,6 +110,10 @@ export const BROWSER_PATHS = {
       join(process.env.LOCALAPPDATA ?? "", "BraveSoftware", "Brave-Browser"),
       join(process.env.PROGRAMFILES ?? "", "BraveSoftware", "Brave-Browser"),
     ],
+    vivaldi: [
+      join(process.env.LOCALAPPDATA ?? "", "Vivaldi", "Application"),
+      join(process.env.PROGRAMFILES ?? "", "Vivaldi", "Application"),
+    ],
   },
   linux: {
     chrome: [
@@ -134,6 +143,12 @@ export const BROWSER_PATHS = {
     ],
     opera: [`${homedir()}/.config/opera`, "/usr/bin/opera", "/usr/lib/opera"],
     "opera-gx": [`${homedir()}/.config/opera-gx`, "/usr/bin/opera-gx"],
+    vivaldi: [
+      `${homedir()}/.config/vivaldi`,
+      "/usr/bin/vivaldi",
+      "/usr/bin/vivaldi-stable",
+      "/opt/vivaldi",
+    ],
   },
 };
 
@@ -175,6 +190,7 @@ export const CHROMIUM_DATA_DIRS: Partial<
       "BraveSoftware",
       "Brave-Browser",
     ),
+    vivaldi: join(homedir(), "Library", "Application Support", "Vivaldi"),
   },
   win32: {
     // Chrome and Edge store profiles under …\User Data on Windows
@@ -208,6 +224,7 @@ export const CHROMIUM_DATA_DIRS: Partial<
       "Brave-Browser",
       "User Data",
     ),
+    vivaldi: join(process.env.LOCALAPPDATA ?? "", "Vivaldi", "User Data"),
   },
   linux: {
     chrome: join(homedir(), ".config", "google-chrome"),
@@ -215,6 +232,7 @@ export const CHROMIUM_DATA_DIRS: Partial<
     opera: join(homedir(), ".config", "opera"),
     "opera-gx": join(homedir(), ".config", "opera-gx"),
     brave: join(homedir(), ".config", "BraveSoftware", "Brave-Browser"),
+    vivaldi: join(homedir(), ".config", "vivaldi"),
   },
 };
 
@@ -295,6 +313,8 @@ function getBrowserVersion(browser: BrowserType): string | undefined {
           "/Applications/Opera.app/Contents/MacOS/Opera --version 2>/dev/null",
         "opera-gx":
           "/Applications/Opera\\ GX.app/Contents/MacOS/Opera\\ GX --version 2>/dev/null",
+        vivaldi:
+          "/Applications/Vivaldi.app/Contents/MacOS/Vivaldi --version 2>/dev/null",
       };
       command = versionCommands[browser];
     } else if (isLinux()) {
@@ -307,6 +327,8 @@ function getBrowserVersion(browser: BrowserType): string | undefined {
           "brave-browser --version 2>/dev/null || brave-browser-stable --version 2>/dev/null",
         opera: "opera --version 2>/dev/null",
         "opera-gx": "opera-gx --version 2>/dev/null",
+        vivaldi:
+          "vivaldi --version 2>/dev/null || vivaldi-stable --version 2>/dev/null",
       };
       command = versionCommands[browser];
     } else if (isWindows()) {
@@ -471,6 +493,7 @@ export function detectAvailableBrowsers(): AvailableBrowser[] {
     "brave",
     "opera",
     "opera-gx",
+    "vivaldi",
   ];
 
   const available: AvailableBrowser[] = [];
@@ -525,6 +548,7 @@ function getBrowserDisplayName(browser: BrowserType): string {
     brave: "Brave",
     opera: "Opera",
     "opera-gx": "Opera GX",
+    vivaldi: "Vivaldi",
   };
   return names[browser];
 }
@@ -596,6 +620,7 @@ export function suggestBrowser(): BrowserType | undefined {
     "firefox",
     "safari",
     "arc",
+    "vivaldi",
     "opera",
     "opera-gx",
   ];

--- a/src/core/browsers/BrowserDetector.ts
+++ b/src/core/browsers/BrowserDetector.ts
@@ -20,7 +20,8 @@ export type BrowserType =
   | "arc"
   | "brave"
   | "opera"
-  | "opera-gx";
+  | "opera-gx"
+  | "vivaldi";
 
 /**
  * Magic bytes for Safari binary cookies format
@@ -149,6 +150,7 @@ export function isValidBrowserType(browser: string): browser is BrowserType {
     "brave",
     "opera",
     "opera-gx",
+    "vivaldi",
   ];
   return validTypes.includes(browser as BrowserType);
 }
@@ -168,6 +170,7 @@ export function getBrowserDisplayName(browser: BrowserType): string {
     brave: "Brave",
     opera: "Opera",
     "opera-gx": "Opera GX",
+    vivaldi: "Vivaldi",
   };
   return displayNames[browser];
 }

--- a/src/core/browsers/StrategyFactory.ts
+++ b/src/core/browsers/StrategyFactory.ts
@@ -20,6 +20,7 @@ import { FirefoxCookieQueryStrategy } from "./firefox/FirefoxCookieQueryStrategy
 import { OperaCookieQueryStrategy } from "./opera/OperaCookieQueryStrategy";
 import { OperaGXCookieQueryStrategy } from "./opera/OperaGXCookieQueryStrategy";
 import { SafariCookieQueryStrategy } from "./safari/SafariCookieQueryStrategy";
+import { VivaldiCookieQueryStrategy } from "./vivaldi/VivaldiCookieQueryStrategy";
 
 /**
  * A strategy that can query cookies - either a single browser or composite
@@ -47,6 +48,7 @@ const STRATEGY_REGISTRY: Record<BrowserType, StrategyConstructor> = {
   brave: BraveCookieQueryStrategy,
   opera: OperaCookieQueryStrategy,
   "opera-gx": OperaGXCookieQueryStrategy,
+  vivaldi: VivaldiCookieQueryStrategy,
 };
 
 /**

--- a/src/core/browsers/__tests__/StrategyFactory.test.ts
+++ b/src/core/browsers/__tests__/StrategyFactory.test.ts
@@ -10,6 +10,7 @@ import { FirefoxCookieQueryStrategy } from "../firefox/FirefoxCookieQueryStrateg
 import { OperaCookieQueryStrategy } from "../opera/OperaCookieQueryStrategy";
 import { OperaGXCookieQueryStrategy } from "../opera/OperaGXCookieQueryStrategy";
 import { SafariCookieQueryStrategy } from "../safari/SafariCookieQueryStrategy";
+import { VivaldiCookieQueryStrategy } from "../vivaldi/VivaldiCookieQueryStrategy";
 import {
   createBrowserStrategy,
   createCompositeStrategy,
@@ -67,6 +68,12 @@ describe("createBrowserStrategy", () => {
     expect(strategy).toBeInstanceOf(OperaGXCookieQueryStrategy);
     expect(strategy).toBeInstanceOf(BaseCookieQueryStrategy);
   });
+
+  it("returns a Vivaldi strategy for 'vivaldi'", () => {
+    const strategy = createBrowserStrategy("vivaldi");
+    expect(strategy).toBeInstanceOf(VivaldiCookieQueryStrategy);
+    expect(strategy).toBeInstanceOf(BaseCookieQueryStrategy);
+  });
 });
 
 describe("createCompositeStrategy", () => {
@@ -81,8 +88,8 @@ describe("createCompositeStrategy", () => {
   it("covers the same number of browsers as the strategy registry", () => {
     const registrySize = getAvailableBrowsers().length;
     // createCompositeStrategy hardcodes strategies — this must stay in sync.
-    // Currently: chrome, edge, arc, opera, opera-gx, firefox, safari = 7.
-    expect(registrySize).toBe(8);
+    // Currently: chrome, edge, arc, opera, opera-gx, brave, firefox, safari, vivaldi = 9.
+    expect(registrySize).toBe(9);
   });
 });
 
@@ -146,10 +153,11 @@ describe("getAvailableBrowsers", () => {
     expect(browsers).toContain("brave");
     expect(browsers).toContain("opera");
     expect(browsers).toContain("opera-gx");
+    expect(browsers).toContain("vivaldi");
   });
 
-  it("returns exactly 8 browsers matching the current registry", () => {
-    expect(getAvailableBrowsers()).toHaveLength(8);
+  it("returns exactly 9 browsers matching the current registry", () => {
+    expect(getAvailableBrowsers()).toHaveLength(9);
   });
 });
 
@@ -184,6 +192,10 @@ describe("isBrowserSupported", () => {
 
   it("returns true for 'opera-gx'", () => {
     expect(isBrowserSupported("opera-gx")).toBe(true);
+  });
+
+  it("returns true for 'vivaldi'", () => {
+    expect(isBrowserSupported("vivaldi")).toBe(true);
   });
 
   it("returns false for 'netscape'", () => {

--- a/src/core/browsers/sql/CookieQueryBuilder.ts
+++ b/src/core/browsers/sql/CookieQueryBuilder.ts
@@ -18,7 +18,8 @@ export type SqlBrowserType =
   | "opera"
   | "opera-gx"
   | "brave"
-  | "arc";
+  | "arc"
+  | "vivaldi";
 
 /**
  * SQL query configuration
@@ -120,6 +121,17 @@ const BROWSER_SCHEMAS: Record<SqlBrowserType, BrowserSchema> = {
     httpOnlyColumn: "is_httponly",
   },
   arc: {
+    tableName: "cookies",
+    nameColumn: "name",
+    valueColumn: "value",
+    domainColumn: "host_key",
+    expiryColumn: "expires_utc",
+    encryptedValueColumn: "encrypted_value",
+    pathColumn: "path",
+    secureColumn: "is_secure",
+    httpOnlyColumn: "is_httponly",
+  },
+  vivaldi: {
     tableName: "cookies",
     nameColumn: "name",
     valueColumn: "value",

--- a/src/core/browsers/vivaldi/VivaldiCookieQueryStrategy.ts
+++ b/src/core/browsers/vivaldi/VivaldiCookieQueryStrategy.ts
@@ -1,0 +1,21 @@
+import { ChromiumCookieQueryStrategy } from "../chromium/ChromiumCookieQueryStrategy";
+
+/**
+ * Strategy for querying cookies from Vivaldi browser.
+ * Vivaldi is a Chromium-based browser with standard cookie storage.
+ * Supports optional profile-name filtering via the profileName constructor parameter.
+ * @example
+ * ```typescript
+ * const strategy = new VivaldiCookieQueryStrategy();
+ * const cookies = await strategy.queryCookies('session', 'example.com');
+ * ```
+ */
+export class VivaldiCookieQueryStrategy extends ChromiumCookieQueryStrategy {
+  /**
+   * Creates a new instance of VivaldiCookieQueryStrategy
+   * @param profileName - Optional specific profile name to target
+   */
+  public constructor(profileName?: string) {
+    super("vivaldi", profileName);
+  }
+}

--- a/src/types/schemas.ts
+++ b/src/types/schemas.ts
@@ -422,6 +422,7 @@ export const SqlBrowserTypeSchema = z.enum([
   "opera-gx",
   "brave",
   "arc",
+  "vivaldi",
 ]);
 
 /**


### PR DESCRIPTION
## Summary

- Add `VivaldiCookieQueryStrategy` extending `ChromiumCookieQueryStrategy` with profile filtering support
- Wire Vivaldi into all registries: `BrowserType`, `SqlBrowserType`, `STRATEGY_REGISTRY`, `BROWSER_PATHS`, `CHROMIUM_DATA_DIRS`, `SqlBrowserTypeSchema`
- Add platform-specific paths for macOS, Windows, and Linux
- Update `StrategyFactory.test.ts` with Vivaldi-specific tests and registry count (8 → 9)

## Test plan

- [x] `pnpm type-check` passes
- [x] `pnpm lint` passes
- [x] All 33 StrategyFactory tests pass (including new Vivaldi tests)
- [x] Pre-push validation passes (full `pnpm validate`)