### PR TITLE
refactor(sql): derive SqlBrowserType from Zod schema

### DIFF
--- a/src/core/browsers/sql/CookieQueryBuilder.ts
+++ b/src/core/browsers/sql/CookieQueryBuilder.ts
@@ -3,23 +3,12 @@
  * Provides a centralized, type-safe way to build SQL queries for different browsers
  */
 
-import type { SqlCookieQueryOptions } from "../../../types/schemas";
+import type {
+  SqlBrowserType,
+  SqlCookieQueryOptions,
+} from "../../../types/schemas";
 
-/**
- * Browser types that use SQL databases for cookie storage.
- *
- * Note: "chromium" is defined speculatively for future generic Chromium support.
- */
-export type SqlBrowserType =
-  | "chrome"
-  | "chromium"
-  | "edge"
-  | "firefox"
-  | "opera"
-  | "opera-gx"
-  | "brave"
-  | "arc"
-  | "vivaldi";
+export type { SqlBrowserType };
 
 /**
  * SQL query configuration


### PR DESCRIPTION
## Summary
- Replace hand-maintained SqlBrowserType union in CookieQueryBuilder.ts with re-export of z.infer from schemas.ts
- Eliminates silent divergence when adding new browsers

## Test plan
- [x] pnpm type-check passes
- [x] pnpm lint passes
- [x] Pre-push validation passes