### PR TITLE
refactor(cookies): share browser cookie lookup helper

### DIFF
--- a/src/core/cookies/__tests__/browserCookieWrappers.test.ts
+++ b/src/core/cookies/__tests__/browserCookieWrappers.test.ts
@@ -1,0 +1,39 @@
+import type { ExportedCookie } from "../../../types/schemas";
+
+import { getChromeCookie } from "../getChromeCookie";
+import { getBrowserCookie } from "../getBrowserCookie";
+import { getFirefoxCookie } from "../getFirefoxCookie";
+
+jest.mock("../getBrowserCookie", () => ({
+  getBrowserCookie: jest.fn(),
+}));
+
+describe("browser cookie wrappers", () => {
+  const cookieSpec = { name: "session", domain: "example.com" };
+  const mockCookies: ExportedCookie[] = [
+    {
+      name: "session",
+      value: "abc123",
+      domain: "example.com",
+    },
+  ];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (getBrowserCookie as jest.Mock).mockResolvedValue(mockCookies);
+  });
+
+  it("delegates Chrome cookie lookup to the shared browser helper", async () => {
+    const result = await getChromeCookie(cookieSpec);
+
+    expect(result).toEqual(mockCookies);
+    expect(getBrowserCookie).toHaveBeenCalledWith("chrome", cookieSpec);
+  });
+
+  it("delegates Firefox cookie lookup to the shared browser helper", async () => {
+    const result = await getFirefoxCookie(cookieSpec);
+
+    expect(result).toEqual(mockCookies);
+    expect(getBrowserCookie).toHaveBeenCalledWith("firefox", cookieSpec);
+  });
+});

--- a/src/core/cookies/__tests__/getBrowserCookie.test.ts
+++ b/src/core/cookies/__tests__/getBrowserCookie.test.ts
@@ -1,0 +1,65 @@
+import type { ExportedCookie } from "../../../types/schemas";
+import logger from "../../../utils/logger";
+import { getBrowserDisplayName } from "../../browsers/BrowserDetector";
+import { createBrowserStrategy } from "../../browsers/StrategyFactory";
+import { getBrowserCookie } from "../getBrowserCookie";
+
+jest.mock("../../browsers/StrategyFactory", () => ({
+  createBrowserStrategy: jest.fn(),
+}));
+
+jest.mock("../../browsers/BrowserDetector", () => ({
+  getBrowserDisplayName: jest.fn(),
+}));
+
+jest.mock("../../../utils/logger", () => ({
+  __esModule: true,
+  default: {
+    warn: jest.fn(),
+  },
+}));
+
+describe("getBrowserCookie", () => {
+  const cookieSpec = { name: "session", domain: "example.com" };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (getBrowserDisplayName as jest.Mock).mockImplementation(
+      (browser: string) => browser,
+    );
+  });
+
+  it("uses the browser strategy factory to query cookies", async () => {
+    const mockCookies: ExportedCookie[] = [
+      {
+        name: "session",
+        value: "abc123",
+        domain: "example.com",
+      },
+    ];
+    const queryCookies = jest.fn().mockResolvedValue(mockCookies);
+
+    (createBrowserStrategy as jest.Mock).mockReturnValue({ queryCookies });
+
+    const result = await getBrowserCookie("chrome", cookieSpec);
+
+    expect(result).toEqual(mockCookies);
+    expect(createBrowserStrategy).toHaveBeenCalledWith("chrome");
+    expect(queryCookies).toHaveBeenCalledWith("session", "example.com");
+  });
+
+  it("logs a warning and returns an empty array when querying fails", async () => {
+    const queryCookies = jest.fn().mockRejectedValue(new Error("boom"));
+
+    (createBrowserStrategy as jest.Mock).mockReturnValue({ queryCookies });
+    (getBrowserDisplayName as jest.Mock).mockReturnValue("Google Chrome");
+
+    const result = await getBrowserCookie("chrome", cookieSpec);
+
+    expect(result).toEqual([]);
+    expect(logger.warn).toHaveBeenCalledWith(
+      "Error querying Google Chrome cookies:",
+      "boom",
+    );
+  });
+});

--- a/src/core/cookies/getBrowserCookie.ts
+++ b/src/core/cookies/getBrowserCookie.ts
@@ -1,0 +1,32 @@
+import type { CookieSpec, ExportedCookie } from "../../types/schemas";
+import { getErrorMessage } from "../../utils/errorUtils";
+import logger from "../../utils/logger";
+import {
+  type BrowserType,
+  getBrowserDisplayName,
+} from "../browsers/BrowserDetector";
+import { createBrowserStrategy } from "../browsers/StrategyFactory";
+
+/**
+ * Retrieves cookies from a specific browser strategy.
+ * @param browser - The browser whose cookie store should be queried
+ * @param cookieSpec - The cookie specification containing search criteria
+ * @returns An array of ExportedCookie objects that match the specification
+ */
+export async function getBrowserCookie(
+  browser: BrowserType,
+  cookieSpec: CookieSpec,
+): Promise<ExportedCookie[]> {
+  try {
+    const strategy = createBrowserStrategy(browser);
+    return await strategy.queryCookies(cookieSpec.name, cookieSpec.domain);
+  } catch (error: unknown) {
+    logger.warn(
+      `Error querying ${getBrowserDisplayName(browser)} cookies:`,
+      getErrorMessage(error),
+    );
+    return [];
+  }
+}
+
+export default getBrowserCookie;

--- a/src/core/cookies/getChromeCookie.ts
+++ b/src/core/cookies/getChromeCookie.ts
@@ -1,6 +1,6 @@
 import type { CookieSpec, ExportedCookie } from "../../types/schemas";
-import logger from "../../utils/logger";
-import { ChromeCookieQueryStrategy } from "../browsers/chrome/ChromeCookieQueryStrategy";
+
+import { getBrowserCookie } from "./getBrowserCookie";
 
 /**
  * Retrieves cookies from Chrome browser storage that match the specified criteria.
@@ -24,20 +24,10 @@ import { ChromeCookieQueryStrategy } from "../browsers/chrome/ChromeCookieQueryS
  * });
  * ```
  */
-export async function getChromeCookie(
+export function getChromeCookie(
   cookieSpec: CookieSpec,
 ): Promise<ExportedCookie[]> {
-  try {
-    const strategy = new ChromeCookieQueryStrategy();
-    const cookies = await strategy.queryCookies(
-      cookieSpec.name,
-      cookieSpec.domain,
-    );
-    return cookies;
-  } catch (error: unknown) {
-    logger.warn("Error querying Chrome cookies:", error);
-    return [];
-  }
+  return getBrowserCookie("chrome", cookieSpec);
 }
 
 /**

--- a/src/core/cookies/getFirefoxCookie.ts
+++ b/src/core/cookies/getFirefoxCookie.ts
@@ -1,7 +1,6 @@
 import type { CookieSpec, ExportedCookie } from "../../types/schemas";
-import { getErrorMessage } from "../../utils/errorUtils";
-import logger from "../../utils/logger";
-import { FirefoxCookieQueryStrategy } from "../browsers/firefox/FirefoxCookieQueryStrategy";
+
+import { getBrowserCookie } from "./getBrowserCookie";
 
 /**
  * Retrieves cookies from Firefox browser storage that match the specified criteria.
@@ -25,20 +24,10 @@ import { FirefoxCookieQueryStrategy } from "../browsers/firefox/FirefoxCookieQue
  * });
  * ```
  */
-export async function getFirefoxCookie(
+export function getFirefoxCookie(
   cookieSpec: CookieSpec,
 ): Promise<ExportedCookie[]> {
-  try {
-    const strategy = new FirefoxCookieQueryStrategy();
-    const cookies = await strategy.queryCookies(
-      cookieSpec.name,
-      cookieSpec.domain,
-    );
-    return cookies;
-  } catch (error: unknown) {
-    logger.warn("Error querying Firefox cookies:", getErrorMessage(error));
-    return [];
-  }
+  return getBrowserCookie("firefox", cookieSpec);
 }
 
 /**


### PR DESCRIPTION
## Summary
- add a shared `getBrowserCookie` helper for browser-specific strategy queries
- delegate the Chrome and Firefox convenience helpers to the shared implementation
- add focused tests for helper behavior and wrapper delegation

## Verification
- `pnpm run type-check`
- `pnpm run lint`
- `pnpm test`
- `pnpm run validate` (via pre-push hook on Node 22)

Fixes #479