### PR TITLE
refactor(browsers): deduplicate display names and remove redundant wrappers

### DIFF
--- a/src/core/browsers/BrowserAvailability.ts
+++ b/src/core/browsers/BrowserAvailability.ts
@@ -535,15 +535,6 @@ export function detectAvailableBrowsers(): AvailableBrowser[] {
 }
 
 /**
- * Checks if a specific browser is available
- * @param browser - The browser type to check
- * @returns True if the browser is available
- */
-export function isBrowserAvailable(browser: BrowserType): boolean {
-  return checkBrowserInstalled(browser);
-}
-
-/**
  * Gets detailed information about a specific browser
  * @param browser - The browser type
  * @returns Browser information or undefined if not available

--- a/src/core/browsers/StrategyFactory.ts
+++ b/src/core/browsers/StrategyFactory.ts
@@ -163,12 +163,3 @@ export function createStrategy(options?: {
 export function getAvailableBrowsers(): BrowserType[] {
   return Object.keys(STRATEGY_REGISTRY) as BrowserType[];
 }
-
-/**
- * Checks if a browser is supported
- * @param browser - The browser to check
- * @returns True if the browser is supported
- */
-export function isBrowserSupported(browser: string): boolean {
-  return isValidBrowserType(browser);
-}

--- a/src/core/browsers/__tests__/StrategyFactory.test.ts
+++ b/src/core/browsers/__tests__/StrategyFactory.test.ts
@@ -11,13 +11,13 @@ import { OperaCookieQueryStrategy } from "../opera/OperaCookieQueryStrategy";
 import { OperaGXCookieQueryStrategy } from "../opera/OperaGXCookieQueryStrategy";
 import { SafariCookieQueryStrategy } from "../safari/SafariCookieQueryStrategy";
 import { VivaldiCookieQueryStrategy } from "../vivaldi/VivaldiCookieQueryStrategy";
+import { isValidBrowserType } from "../BrowserDetector";
 import {
   createBrowserStrategy,
   createCompositeStrategy,
   createSelectiveCompositeStrategy,
   createStrategy,
   getAvailableBrowsers,
-  isBrowserSupported,
 } from "../StrategyFactory";
 
 describe("createBrowserStrategy", () => {
@@ -161,52 +161,52 @@ describe("getAvailableBrowsers", () => {
   });
 });
 
-describe("isBrowserSupported", () => {
+describe("isValidBrowserType", () => {
   it("returns true for 'chrome'", () => {
-    expect(isBrowserSupported("chrome")).toBe(true);
+    expect(isValidBrowserType("chrome")).toBe(true);
   });
 
   it("returns true for 'firefox'", () => {
-    expect(isBrowserSupported("firefox")).toBe(true);
+    expect(isValidBrowserType("firefox")).toBe(true);
   });
 
   it("returns true for 'safari'", () => {
-    expect(isBrowserSupported("safari")).toBe(true);
+    expect(isValidBrowserType("safari")).toBe(true);
   });
 
   it("returns true for 'edge'", () => {
-    expect(isBrowserSupported("edge")).toBe(true);
+    expect(isValidBrowserType("edge")).toBe(true);
   });
 
   it("returns true for 'arc'", () => {
-    expect(isBrowserSupported("arc")).toBe(true);
+    expect(isValidBrowserType("arc")).toBe(true);
   });
 
   it("returns true for 'brave'", () => {
-    expect(isBrowserSupported("brave")).toBe(true);
+    expect(isValidBrowserType("brave")).toBe(true);
   });
 
   it("returns true for 'opera'", () => {
-    expect(isBrowserSupported("opera")).toBe(true);
+    expect(isValidBrowserType("opera")).toBe(true);
   });
 
   it("returns true for 'opera-gx'", () => {
-    expect(isBrowserSupported("opera-gx")).toBe(true);
+    expect(isValidBrowserType("opera-gx")).toBe(true);
   });
 
   it("returns true for 'vivaldi'", () => {
-    expect(isBrowserSupported("vivaldi")).toBe(true);
+    expect(isValidBrowserType("vivaldi")).toBe(true);
   });
 
   it("returns false for 'netscape'", () => {
-    expect(isBrowserSupported("netscape")).toBe(false);
+    expect(isValidBrowserType("netscape")).toBe(false);
   });
 
   it("returns false for an empty string", () => {
-    expect(isBrowserSupported("")).toBe(false);
+    expect(isValidBrowserType("")).toBe(false);
   });
 
   it("returns false for 'CHROME' (case-sensitive)", () => {
-    expect(isBrowserSupported("CHROME")).toBe(false);
+    expect(isValidBrowserType("CHROME")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- Remove duplicate `getBrowserDisplayName` from `BrowserAvailability.ts`, import from `BrowserDetector.ts` (#476)
- Remove unused `isBrowserAvailable` wrapper around `checkBrowserInstalled` (#477)
- Remove `isBrowserSupported` wrapper around `isValidBrowserType`, update tests to use `isValidBrowserType` directly (#477)

## Test plan
- [x] `pnpm type-check` passes
- [x] `pnpm lint` passes
- [x] All 33 StrategyFactory tests pass with `isValidBrowserType`
- [x] All 48 browser tests pass

Fixes #476
Fixes #477