### PR TITLE
perf(browsers): reduce synchronous existsSync calls in file discovery

### DIFF
--- a/src/core/browsers/BrowserAvailability.ts
+++ b/src/core/browsers/BrowserAvailability.ts
@@ -3,9 +3,11 @@
  * @module BrowserAvailability
  */
 
-import { existsSync, readdirSync } from "node:fs";
+import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+
+import fg from "fast-glob";
 
 import { createTaggedLogger } from "@utils/logHelpers";
 import { getPlatform, isLinux, isMacOS, isWindows } from "@utils/platformUtils";
@@ -259,17 +261,26 @@ export const FIREFOX_DATA_DIRS: Partial<Record<string, string[]>> = {
   linux: [join(homedir(), ".mozilla", "firefox")],
 };
 
+/** Module-level cache for browser installation checks — installations don't change during process lifetime */
+const installCache = new Map<BrowserType, boolean>();
+
 /**
  * Checks if a browser is installed by looking for its paths
  * @param browser - The browser type to check
  * @returns True if the browser is installed
  */
 function checkBrowserInstalled(browser: BrowserType): boolean {
+  const cached = installCache.get(browser);
+  if (cached !== undefined) {
+    return cached;
+  }
+
   const platform = getPlatform();
 
   // Defensive check: handle unexpected platform values gracefully
   // Check if platform exists in BROWSER_PATHS before accessing
   if (!(platform in BROWSER_PATHS)) {
+    installCache.set(browser, false);
     return false;
   }
 
@@ -282,10 +293,12 @@ function checkBrowserInstalled(browser: BrowserType): boolean {
   for (const path of paths) {
     if (existsSync(path)) {
       logger.debug("Found browser installation", { browser, path });
+      installCache.set(browser, true);
       return true;
     }
   }
 
+  installCache.set(browser, false);
   return false;
 }
 
@@ -370,27 +383,16 @@ export async function getBrowserVersionAsync(
  * @returns Array of profile paths found
  */
 function findChromiumProfiles(basePath: string): string[] {
-  const profiles: string[] = [];
-
   if (!existsSync(basePath)) {
-    return profiles;
+    return [];
   }
 
-  // Look for Default profile
-  const defaultProfile = join(basePath, "Default");
-  if (existsSync(defaultProfile)) {
-    profiles.push(defaultProfile);
-  }
-
-  // Look for numbered profiles (Profile 1, Profile 2, etc.)
-  for (let i = 1; i <= 10; i++) {
-    const profilePath = join(basePath, `Profile ${i}`);
-    if (existsSync(profilePath)) {
-      profiles.push(profilePath);
-    }
-  }
-
-  return profiles;
+  // Single glob replaces 12 existsSync calls (Default + Profile 1..10)
+  return fg.sync(["Default", "Profile *"], {
+    cwd: basePath,
+    onlyDirectories: true,
+    absolute: true,
+  });
 }
 
 /**
@@ -399,22 +401,12 @@ function findChromiumProfiles(basePath: string): string[] {
  * @returns Array of profile paths found
  */
 function findFirefoxProfilesInPath(basePath: string): string[] {
-  const profiles: string[] = [];
-
-  if (!existsSync(basePath)) {
-    return profiles;
-  }
-
-  const profileDirs: string[] = readdirSync(basePath);
-  for (const dir of profileDirs) {
-    // Firefox profiles usually have .default or .default-release suffix
-    if (dir.includes("default")) {
-      const profilePath = join(basePath, dir);
-      profiles.push(profilePath);
-    }
-  }
-
-  return profiles;
+  // Single glob replaces existsSync + readdirSync + manual filter
+  return fg.sync(["*default*"], {
+    cwd: basePath,
+    onlyDirectories: true,
+    absolute: true,
+  });
 }
 
 /**

--- a/src/core/browsers/sql/EnhancedCookieQueryService.ts
+++ b/src/core/browsers/sql/EnhancedCookieQueryService.ts
@@ -3,9 +3,11 @@
  * Combines query building, connection management, and validation in a unified interface
  */
 
-import { existsSync, readdirSync } from "node:fs";
+import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
+
+import fg from "fast-glob";
 import type { SqliteDatabase } from "./adapters/DatabaseAdapter";
 import { createTaggedLogger, logError } from "@utils/logHelpers";
 import { getPlatform } from "@utils/platformUtils";
@@ -457,21 +459,11 @@ export class EnhancedCookieQueryService {
       return [];
     }
 
-    const cookieFiles: string[] = [];
-
-    // Check Default profile
-    const defaultCookies = join(dataDir, "Default", "Cookies");
-    if (existsSync(defaultCookies)) {
-      cookieFiles.push(defaultCookies);
-    }
-
-    // Check numbered profiles (Profile 1 through Profile 10)
-    for (let i = 1; i <= 10; i++) {
-      const profileCookies = join(dataDir, `Profile ${i}`, "Cookies");
-      if (existsSync(profileCookies)) {
-        cookieFiles.push(profileCookies);
-      }
-    }
+    // Single glob replaces 12 existsSync calls (Default/Cookies + Profile 1..10/Cookies)
+    const cookieFiles = fg.sync(["{Default,Profile *}/Cookies"], {
+      cwd: dataDir,
+      absolute: true,
+    });
 
     logger.debug("Discovered Chromium cookie files", {
       browser,
@@ -514,23 +506,11 @@ export class EnhancedCookieQueryService {
       return [];
     }
 
-    const cookieFiles: string[] = [];
-
-    try {
-      const entries = readdirSync(profilesDir);
-      for (const entry of entries) {
-        if (entry.includes("default")) {
-          const cookiesPath = join(profilesDir, entry, "cookies.sqlite");
-          if (existsSync(cookiesPath)) {
-            cookieFiles.push(cookiesPath);
-          }
-        }
-      }
-    } catch {
-      logger.debug("Failed to read Firefox profiles directory", {
-        profilesDir,
-      });
-    }
+    // Single glob replaces readdirSync + existsSync loop
+    const cookieFiles = fg.sync(["*default*/cookies.sqlite"], {
+      cwd: profilesDir,
+      absolute: true,
+    });
 
     logger.debug("Discovered Firefox cookie files", {
       count: cookieFiles.length,

--- a/src/core/browsers/sql/__tests__/EnhancedCookieQueryService.test.ts
+++ b/src/core/browsers/sql/__tests__/EnhancedCookieQueryService.test.ts
@@ -27,7 +27,11 @@ jest.mock("../adapters/DatabaseAdapter");
 // Mock node:fs for file discovery tests
 jest.mock("node:fs", () => ({
   existsSync: jest.fn().mockReturnValue(false),
-  readdirSync: jest.fn().mockReturnValue([]),
+}));
+
+// Mock fast-glob for file discovery tests (replaces readdirSync-based iteration)
+jest.mock("fast-glob", () => ({
+  sync: jest.fn().mockReturnValue([]),
 }));
 
 // Mock getPlatform to return "darwin" so path lookups are deterministic across CI
@@ -44,7 +48,7 @@ describe("EnhancedCookieQueryService", () => {
   let mockStmt: { all: jest.Mock; get: jest.Mock; run: jest.Mock };
   let manager: DatabaseConnectionManager;
   let mockExistsSync: jest.Mock;
-  let mockReaddirSync: jest.Mock;
+  let mockFgSync: jest.Mock;
 
   beforeEach(() => {
     mockStmt = {
@@ -65,9 +69,11 @@ describe("EnhancedCookieQueryService", () => {
 
     const fs = require("node:fs");
     mockExistsSync = fs.existsSync as jest.Mock;
-    mockReaddirSync = fs.readdirSync as jest.Mock;
     mockExistsSync.mockReturnValue(false);
-    mockReaddirSync.mockReturnValue([]);
+
+    const fg = require("fast-glob");
+    mockFgSync = fg.sync as jest.Mock;
+    mockFgSync.mockReturnValue([]);
 
     manager = new DatabaseConnectionManager({
       maxConnections: 2,
@@ -156,21 +162,17 @@ describe("EnhancedCookieQueryService", () => {
 
   describe("discoverBrowserFiles via queryCookies", () => {
     it("discovers Chromium cookie files from Default profile", async () => {
+      // Data dir must exist for the guard check
       mockExistsSync.mockImplementation((...args: unknown[]) => {
         const p = String(args[0]).replace(/\\/g, "/");
-        if (p.endsWith("/Default/Cookies")) {
-          return true;
-        }
-        // Data dir must exist
-        if (
+        return (
           p.includes("Chrome") &&
           !p.includes("Default") &&
           !p.includes("Profile")
-        ) {
-          return true;
-        }
-        return false;
+        );
       });
+      // fg.sync returns the discovered cookie files
+      mockFgSync.mockReturnValue(["/fake/Chrome/Default/Cookies"]);
 
       const options: EnhancedQueryOptions = {
         browser: "chrome",
@@ -184,20 +186,14 @@ describe("EnhancedCookieQueryService", () => {
     });
 
     it("discovers Firefox cookie files from profile directories", async () => {
+      // Profiles dir must exist for the guard check
       mockExistsSync.mockImplementation((...args: unknown[]) => {
         const p = String(args[0]).replace(/\\/g, "/");
-        if (p.includes("Firefox") || p.includes("firefox")) {
-          return true;
-        }
-        if (p.endsWith("abc123.default/cookies.sqlite")) {
-          return true;
-        }
-        return false;
+        return p.includes("Firefox") || p.includes("firefox");
       });
-      mockReaddirSync.mockReturnValue([
-        "abc123.default",
-        "profiles.ini",
-        "xyz789.default-release",
+      // fg.sync returns the discovered cookie files
+      mockFgSync.mockReturnValue([
+        "/fake/Firefox/Profiles/abc123.default/cookies.sqlite",
       ]);
 
       const options: EnhancedQueryOptions = {
@@ -207,27 +203,20 @@ describe("EnhancedCookieQueryService", () => {
       };
 
       await service.queryCookies(options);
-      // Should have found at least the abc123.default profile
-      expect(mockExistsSync).toHaveBeenCalledWith(
-        expect.stringContaining("cookies.sqlite"),
-      );
+      // Should have attempted to query the discovered file
+      expect(mockDb.prepare).toHaveBeenCalled();
     });
 
     it("discovers Brave cookie files from Default profile", async () => {
       mockExistsSync.mockImplementation((...args: unknown[]) => {
         const p = String(args[0]).replace(/\\/g, "/");
-        if (p.endsWith("/Default/Cookies")) {
-          return true;
-        }
-        if (
+        return (
           p.includes("Brave") &&
           !p.includes("Default") &&
           !p.includes("Profile")
-        ) {
-          return true;
-        }
-        return false;
+        );
       });
+      mockFgSync.mockReturnValue(["/fake/Brave/Default/Cookies"]);
 
       const options: EnhancedQueryOptions = {
         browser: "brave",
@@ -242,18 +231,11 @@ describe("EnhancedCookieQueryService", () => {
     it("discovers Arc cookie files from Default profile", async () => {
       mockExistsSync.mockImplementation((...args: unknown[]) => {
         const p = String(args[0]).replace(/\\/g, "/");
-        if (p.endsWith("/Default/Cookies")) {
-          return true;
-        }
-        if (
-          p.includes("Arc") &&
-          !p.includes("Default") &&
-          !p.includes("Profile")
-        ) {
-          return true;
-        }
-        return false;
+        return (
+          p.includes("Arc") && !p.includes("Default") && !p.includes("Profile")
+        );
       });
+      mockFgSync.mockReturnValue(["/fake/Arc/Default/Cookies"]);
 
       const options: EnhancedQueryOptions = {
         browser: "arc",
@@ -292,16 +274,14 @@ describe("EnhancedCookieQueryService", () => {
     it("returns empty array when Chromium data dir exists but no profiles found", async () => {
       mockExistsSync.mockImplementation((...args: unknown[]) => {
         const p = String(args[0]).replace(/\\/g, "/");
-        // Data dir exists but no profile Cookies files
-        if (
+        return (
           p.includes("Chrome") &&
           !p.includes("Default") &&
           !p.includes("Profile")
-        ) {
-          return true;
-        }
-        return false;
+        );
       });
+      // fg.sync returns empty — no profile directories found
+      mockFgSync.mockReturnValue([]);
 
       const options: EnhancedQueryOptions = {
         browser: "chrome",


### PR DESCRIPTION
## Summary

- Replace iterative `existsSync` calls with single `fg.sync()` glob patterns in Chromium and Firefox profile discovery
- Cache browser installation checks at module level (`installCache` Map) since installations don't change during process lifetime
- Update `EnhancedCookieQueryService` tests to mock `fast-glob` instead of `readdirSync`

Reduces 20-40 synchronous stat syscalls per query lifecycle to ~3-5 glob calls.

Closes #489

## Test plan

- [x] `pnpm type-check` passes
- [x] `pnpm lint` passes (Biome, 225 files)
- [x] All 588 tests pass
- [x] Pre-push validation passes (full validate pipeline)