### PR TITLE
fix: add ~/.config/mozilla/firefox to Linux Firefox profile search paths

### DIFF
--- a/src/core/browsers/BrowserAvailability.ts
+++ b/src/core/browsers/BrowserAvailability.ts
@@ -127,6 +127,7 @@ export const BROWSER_PATHS = {
     ],
     firefox: [
       `${homedir()}/.mozilla/firefox`,
+      `${homedir()}/.config/mozilla/firefox`,
       "/usr/bin/firefox",
       "/usr/lib/firefox",
       "/snap/firefox",
@@ -258,7 +259,10 @@ export const FIREFOX_DATA_DIRS: Partial<Record<string, string[]>> = {
     ),
     join(homedir(), "AppData", "Roaming", "Mozilla", "Firefox ESR"),
   ],
-  linux: [join(homedir(), ".mozilla", "firefox")],
+  linux: [
+    join(homedir(), ".mozilla", "firefox"),
+    join(homedir(), ".config", "mozilla", "firefox"),
+  ],
 };
 
 /** Module-level cache for browser installation checks — installations don't change during process lifetime */

--- a/src/core/browsers/__tests__/BrowserAvailability.test.ts
+++ b/src/core/browsers/__tests__/BrowserAvailability.test.ts
@@ -6,7 +6,11 @@ import { describe, it, expect } from "@jest/globals";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
-import { CHROMIUM_DATA_DIRS } from "../BrowserAvailability";
+import {
+  BROWSER_PATHS,
+  CHROMIUM_DATA_DIRS,
+  FIREFOX_DATA_DIRS,
+} from "../BrowserAvailability";
 
 describe("CHROMIUM_DATA_DIRS", () => {
   it("has entries for darwin, win32, and linux", () => {
@@ -78,6 +82,46 @@ describe("CHROMIUM_DATA_DIRS", () => {
     it("edge path is under .config/microsoft-edge", () => {
       expect(linux?.["edge"]).toBe(
         join(homedir(), ".config", "microsoft-edge"),
+      );
+    });
+  });
+});
+
+describe("FIREFOX_DATA_DIRS", () => {
+  it("has entries for darwin, win32, and linux", () => {
+    expect(FIREFOX_DATA_DIRS).toHaveProperty("darwin");
+    expect(FIREFOX_DATA_DIRS).toHaveProperty("win32");
+    expect(FIREFOX_DATA_DIRS).toHaveProperty("linux");
+  });
+
+  describe("linux paths", () => {
+    const linux = FIREFOX_DATA_DIRS["linux"];
+
+    it("includes the traditional ~/.mozilla/firefox path", () => {
+      expect(linux).toContainEqual(
+        join(homedir(), ".mozilla", "firefox"),
+      );
+    });
+
+    it("includes the XDG-style ~/.config/mozilla/firefox path", () => {
+      expect(linux).toContainEqual(
+        join(homedir(), ".config", "mozilla", "firefox"),
+      );
+    });
+  });
+});
+
+describe("BROWSER_PATHS", () => {
+  describe("linux firefox paths", () => {
+    const firefoxPaths = BROWSER_PATHS.linux.firefox;
+
+    it("includes the traditional ~/.mozilla/firefox path", () => {
+      expect(firefoxPaths).toContainEqual(`${homedir()}/.mozilla/firefox`);
+    });
+
+    it("includes the XDG-style ~/.config/mozilla/firefox path", () => {
+      expect(firefoxPaths).toContainEqual(
+        `${homedir()}/.config/mozilla/firefox`,
       );
     });
   });

--- a/src/core/browsers/firefox/FirefoxCookieQueryStrategy.ts
+++ b/src/core/browsers/firefox/FirefoxCookieQueryStrategy.ts
@@ -109,8 +109,14 @@ function findFirefoxCookieFiles(
       break;
     }
     case "linux":
-      profileDirs.push(join(home, ".mozilla/firefox"));
-      patterns.push(join(home, ".mozilla/firefox/*/cookies.sqlite"));
+      profileDirs.push(
+        join(home, ".mozilla/firefox"),
+        join(home, ".config/mozilla/firefox"),
+      );
+      patterns.push(
+        join(home, ".mozilla/firefox/*/cookies.sqlite"),
+        join(home, ".config/mozilla/firefox/*/cookies.sqlite"),
+      );
       break;
     default:
       logger.debug("Unsupported platform for Firefox cookie extraction", {


### PR DESCRIPTION
## Problem

On some Linux systems, Firefox stores profiles under `~/.config/mozilla/firefox/` instead of the traditional `~/.mozilla/firefox/`. This affects:

- Arch Linux official Firefox packages
- Certain Flatpak/Snap Firefox configurations
- Distros following XDG Base Directory conventions

The tool silently found no cookies for these users, reporting only "No results" with no indication that the Firefox profile directory was simply not being searched.

## How I found this

I ran `npx @mherod/get-cookie get-cookie --verbose --url company.com` on my Arch Linux machine and got zero results despite having Firefox cookies for that site. The `--verbose` flag only printed the cookieSpecs but didn't reveal what was happening under the hood. After setting `LOG_LEVEL=debug` (discovered by reading the source), I saw `No Firefox profile directories found` — the tool was only looking in `~/.mozilla/firefox/`, but my Firefox (Arch official package) stores profiles in `~/.config/mozilla/firefox/`. *An AI coding assistant (Claude) helped me trace through the codebase to identify all three locations that needed updating.*

## Fix

Add `~/.config/mozilla/firefox` to the Linux Firefox search paths in all three locations:

- **`BROWSER_PATHS`** — browser installation detection
- **`FIREFOX_DATA_DIRS`** — profile listing via `--list-profiles`
- **`findFirefoxCookieFiles()`** — actual cookie file discovery

## Tests

Extended `BrowserAvailability.test.ts` with new test cases for `FIREFOX_DATA_DIRS` and `BROWSER_PATHS` Linux Firefox entries, covering both the traditional and XDG paths.

## Notes

- No API changes
- No breaking changes
- Backward compatible (existing `~/.mozilla/firefox` path is preserved and checked first)