### PR TITLE
test(firefox): cover XDG profile discovery paths

### DIFF
--- a/src/core/browsers/firefox/__tests__/FirefoxCookieQueryStrategy.discovery.test.ts
+++ b/src/core/browsers/firefox/__tests__/FirefoxCookieQueryStrategy.discovery.test.ts
@@ -46,10 +46,9 @@ jest.mock("../../sql/QueryMonitor", () => ({
 
 import { FirefoxCookieQueryStrategy } from "../FirefoxCookieQueryStrategy";
 
-// Mock fast-glob
+// Mock fast-glob — matches the CJS module shape so the strategy's default
+// import (`import fg from "fast-glob"`) resolves to an object with `.sync`.
 jest.mock("fast-glob", () => ({
-  __esModule: true,
-  default: jest.fn(),
   sync: jest.fn(),
 }));
 
@@ -79,7 +78,7 @@ interface MockFastGlob {
   sync: jest.Mock;
 }
 
-describe.skip("FirefoxCookieQueryStrategy - File Discovery", () => {
+describe("FirefoxCookieQueryStrategy - File Discovery", () => {
   let strategy: FirefoxCookieQueryStrategy;
   const originalHome = process.env.HOME;
 
@@ -124,12 +123,21 @@ describe.skip("FirefoxCookieQueryStrategy - File Discovery", () => {
       if (pattern.includes(".mozilla/firefox")) {
         return ["/mock/home/.mozilla/firefox/xyz789/cookies.sqlite"];
       }
+      if (pattern.includes(".config/mozilla/firefox")) {
+        return ["/mock/home/.config/mozilla/firefox/xdg111/cookies.sqlite"];
+      }
       return [];
     });
 
     await strategy.queryCookies("test-cookie", "example.com");
+    // Linux Firefox discovery queries both the traditional and XDG roots.
     expect(sync).toHaveBeenCalledWith(
       expect.stringMatching(/\.mozilla[/\\]firefox[/\\]\*[/\\]cookies\.sqlite/),
+    );
+    expect(sync).toHaveBeenCalledWith(
+      expect.stringMatching(
+        /\.config[/\\]mozilla[/\\]firefox[/\\]\*[/\\]cookies\.sqlite/,
+      ),
     );
   });
 

--- a/src/core/browsers/firefox/__tests__/FirefoxCookieQueryStrategy.fastpath.test.ts
+++ b/src/core/browsers/firefox/__tests__/FirefoxCookieQueryStrategy.fastpath.test.ts
@@ -122,22 +122,36 @@ describe("FirefoxCookieQueryStrategy - Fast Path Optimization", () => {
   });
 
   it("should check platform-specific Firefox directories", async () => {
-    const testCases = [
+    const testCases: Array<{
+      platform: "darwin" | "win32" | "linux";
+      expectedPaths: string[];
+    }> = [
       {
         platform: "darwin",
-        expectedPath: "Library/Application Support/Firefox",
+        expectedPaths: ["Library/Application Support/Firefox"],
       },
-      { platform: "win32", expectedPath: "AppData/Roaming/Mozilla/Firefox" },
-      { platform: "linux", expectedPath: ".mozilla/firefox" },
+      {
+        platform: "win32",
+        expectedPaths: ["AppData/Roaming/Mozilla/Firefox"],
+      },
+      {
+        // Linux discovery covers both the traditional ~/.mozilla/firefox
+        // root and the XDG-style ~/.config/mozilla/firefox root added in
+        // PR #505 for newer Firefox installs.
+        platform: "linux",
+        expectedPaths: [".mozilla/firefox", ".config/mozilla/firefox"],
+      },
     ];
 
-    for (const { platform, expectedPath } of testCases) {
-      mockGetPlatform.mockReturnValue(platform as "darwin" | "win32" | "linux");
+    for (const { platform, expectedPaths } of testCases) {
+      mockGetPlatform.mockReturnValue(platform);
       setupMocksForNoFirefox();
       await strategy.queryCookies("test", "example.com");
-      expect(mockExistsSync).toHaveBeenCalledWith(
-        join("/Users/test", expectedPath),
-      );
+      for (const expectedPath of expectedPaths) {
+        expect(mockExistsSync).toHaveBeenCalledWith(
+          join("/Users/test", expectedPath),
+        );
+      }
     }
   });
 

--- a/src/core/browsers/firefox/__tests__/FirefoxCookieQueryStrategy.fastpath.test.ts
+++ b/src/core/browsers/firefox/__tests__/FirefoxCookieQueryStrategy.fastpath.test.ts
@@ -58,8 +58,6 @@ import { FirefoxCookieQueryStrategy } from "../FirefoxCookieQueryStrategy";
 jest.mock("node:fs");
 jest.mock("node:os");
 jest.mock("fast-glob", () => ({
-  __esModule: true,
-  default: jest.fn(),
   sync: jest.fn(),
 }));
 jest.mock("@utils/platformUtils", () => ({
@@ -107,7 +105,7 @@ function expectEmptyResult(result: unknown[]): void {
   expect(result).toEqual([]);
 }
 
-describe.skip("FirefoxCookieQueryStrategy - Fast Path Optimization", () => {
+describe("FirefoxCookieQueryStrategy - Fast Path Optimization", () => {
   let strategy: FirefoxCookieQueryStrategy;
 
   beforeEach(() => {


### PR DESCRIPTION
## Summary

Two-commit branch that closes #513 and resurrects the Firefox strategy test suites that had drifted into `describe.skip`.

- **`c26d3de`** — `test(firefox): un-skip fastpath suite and fix fast-glob mock`
  - Root cause: the `jest.mock("fast-glob")` factory used `__esModule: true` + `default: jest.fn()`. With that shape, the production strategy's `import fg from "fast-glob"` resolved to `jest.fn()` (no `.sync` method). The captured `mockSync` was therefore `undefined`, breaking every assertion that touched globbing.
  - Fix: simplify the mock factory to `{ sync: jest.fn() }` — matches the working pattern in `EnhancedCookieQueryService.test.ts` and the real fast-glob CJS module shape. Then drop `describe.skip` so the 6 fast-path tests run again, all green.

- **`e63e760`** — `test(firefox): cover XDG profile discovery paths`
  - **fastpath**: reworks the platform-specific directory case to assert *every* expected `existsSync` call per platform. Linux now expects both the traditional `~/.mozilla/firefox` and the XDG-style `~/.config/mozilla/firefox` roots.
  - **discovery**: extends the Linux glob assertions to require `fast-glob` to be called with both `.mozilla/firefox/*/cookies.sqlite` and `.config/mozilla/firefox/*/cookies.sqlite` patterns. The per-pattern mock implementation now also returns a representative cookie file for the XDG path.

## Why split

`c26d3de` is a strictly-mechanical test-infrastructure fix — it doesn't change what's being asserted, just makes the existing assertions actually run. `e63e760` is the actual #513 scope (new assertions for XDG paths). The split makes review easier and the infra fix cherry-pickable.

## Test plan

- [x] `pnpm test src/core/browsers/firefox/` — 14 tests pass across 5 suites, no skipped suites
- [x] `pnpm run validate` — all green; 602 pass, 4 skipped (down from 13 skipped pre-PR thanks to the un-skip)

Closes #513
