### PR TITLE
docs(browsers): document async browser version behavior

### DIFF
--- a/src/core/browsers/BrowserAvailability.ts
+++ b/src/core/browsers/BrowserAvailability.ts
@@ -19,7 +19,16 @@ import type { BrowserType } from "./BrowserDetector";
 const logger = createTaggedLogger("BrowserAvailability");
 
 /**
- * Information about an available browser
+ * Information about an available browser.
+ *
+ * @remarks
+ * The {@link AvailableBrowser.version} field is intentionally optional and is
+ * **not populated** by the synchronous detection paths
+ * ({@link detectAvailableBrowsers} and {@link getBrowserInfo}). Browser
+ * version lookup runs a shell command and is therefore exposed as a separate
+ * async helper — call {@link getBrowserVersionAsync} when a version string is
+ * required. Consumers must treat `version` as potentially `undefined` even
+ * when `installed` is `true`.
  */
 export interface AvailableBrowser {
   type: BrowserType;
@@ -27,6 +36,15 @@ export interface AvailableBrowser {
   installed: boolean;
   profilePaths?: string[];
   executablePath?: string;
+  /**
+   * Browser version string, when known.
+   *
+   * @remarks
+   * Absent from {@link detectAvailableBrowsers} and {@link getBrowserInfo}
+   * results — those paths intentionally skip version detection because it
+   * shells out. Call {@link getBrowserVersionAsync} separately to populate
+   * this field.
+   */
   version?: string;
 }
 
@@ -488,9 +506,30 @@ function findBrowserProfiles(browser: BrowserType): string[] {
 
 /**
  * Detects all available browsers on the current system.
- * This function is synchronous — it checks file system paths only.
- * Browser version detection is async and available separately via
- * {@link getBrowserVersionAsync}.
+ *
+ * @remarks
+ * This function is synchronous — it checks file system paths only and does
+ * **not** populate {@link AvailableBrowser.version}. To get a version string,
+ * call {@link getBrowserVersionAsync} for each browser of interest.
+ *
+ * @example
+ * ```typescript
+ * import {
+ *   detectAvailableBrowsers,
+ *   getBrowserVersionAsync,
+ * } from "@mherod/get-cookie";
+ *
+ * const browsers = await Promise.all(
+ *   detectAvailableBrowsers()
+ *     .filter((b) => b.installed)
+ *     .map(async (b) => ({
+ *       ...b,
+ *       // `b.version` is always undefined here — fill it in via the async helper.
+ *       version: await getBrowserVersionAsync(b.type),
+ *     })),
+ * );
+ * ```
+ *
  * @returns Array of available browser information
  */
 export function detectAvailableBrowsers(): AvailableBrowser[] {
@@ -539,7 +578,12 @@ export function detectAvailableBrowsers(): AvailableBrowser[] {
 
 /**
  * Gets detailed information about a specific browser.
- * Version is not included — use {@link getBrowserVersionAsync} separately if needed.
+ *
+ * @remarks
+ * The returned record's {@link AvailableBrowser.version} field is always
+ * `undefined` here — this synchronous path checks file system paths only.
+ * Use {@link getBrowserVersionAsync} to look the version up when required.
+ *
  * @param browser - The browser type
  * @returns Browser information or undefined if not available
  */


### PR DESCRIPTION
## Summary

Documents in JSDoc — and therefore in the rendered TypeDoc API reference — that `AvailableBrowser.version` is intentionally absent from the synchronous detection paths. Consumers who expected `installed: true` to imply a populated `version` field were getting silently surprised; the async helper exists, but the contract was never explicit.

## Changes

`src/core/browsers/BrowserAvailability.ts`:

- **`AvailableBrowser` interface**: adds an interface-level `@remarks` and a field-level `@remarks` on `version` stating that the field is intentionally absent from sync paths and pointing consumers at `getBrowserVersionAsync`.
- **`detectAvailableBrowsers`**: tightens the existing pointer to `getBrowserVersionAsync` and adds a worked `@example` showing how to fan the async version lookup out over the sync result.
- **`getBrowserInfo`**: states plainly that the returned record's `version` is always `undefined` from this entry point.

## Why not edit the markdown reference docs

`docs/reference/index.md` is hand-curated (carries a `v2.1.1` header) and TypeDoc regeneration would overwrite it destructively — that's out of scope for this PR and worth its own follow-up. The `{@link}` cross-references in the new JSDoc go into TypeDoc's structured output under `docs/reference/index/`, which is the actively-generated reference and is the right surface for this change.

## Test plan

- [x] `pnpm run docs` — TypeDoc regenerates cleanly: 0 errors, only the 4 pre-existing Zod schema warnings (`BrowserNameSchema`, `CookieSpecSchema`, `ExportedCookieSchema`, `RenderOptionsSchema`); VitePress build succeeds.
- [x] `pnpm run validate` — 593 pass, 13 skipped, no new failures.
- [x] All `{@link}` references resolve (`detectAvailableBrowsers`, `getBrowserInfo`, `getBrowserVersionAsync`, `AvailableBrowser`, `AvailableBrowser.version`).

## Acceptance criteria

Per #516:
- [x] User-facing docs mention that `AvailableBrowser.version` may be absent from sync detection results — done on the interface and both sync entry points.
- [x] Docs reference `getBrowserVersionAsync()` for version lookup — done via three `{@link}` cross-references.
- [x] Any browser metadata examples avoid implying version is always present — the new `@example` on `detectAvailableBrowsers` shows the correct fan-out pattern with an inline comment that `b.version` is always undefined at that point.
- [x] `pnpm run docs` and `pnpm run check-links` pass.

Closes #516
