### PR TITLE
perf: avoid timestamp buffer copies in Safari parser

### DIFF
--- a/src/core/browsers/safari/BinaryCodableCookie.ts
+++ b/src/core/browsers/safari/BinaryCodableCookie.ts
@@ -374,19 +374,11 @@ export class BinaryCodableCookie {
    */
   private readTimestamps(container: BinaryCodableContainer): void {
     // Read expiration time (8 bytes, little-endian double)
-    const expirationBuffer = Buffer.alloc(8);
-    for (let i = 0; i < 8; i++) {
-      expirationBuffer[i] = container.buffer[container.offset + i]!;
-    }
-    const expiration = expirationBuffer.readDoubleLE(0);
+    const expiration = container.buffer.readDoubleLE(container.offset);
     container.offset += 8;
 
     // Read creation time (8 bytes, little-endian double)
-    const creationBuffer = Buffer.alloc(8);
-    for (let i = 0; i < 8; i++) {
-      creationBuffer[i] = container.buffer[container.offset + i]!;
-    }
-    const creation = creationBuffer.readDoubleLE(0);
+    const creation = container.buffer.readDoubleLE(container.offset);
     container.offset += 8;
 
     // Store raw timestamps (seconds since 2001-01-01)


### PR DESCRIPTION
## Summary
- replace the two alloc-and-copy timestamp reads in `BinaryCodableCookie.readTimestamps`
- read the expiration and creation doubles directly from the existing Safari cookie buffer
- keep the same offset advancement and parsing behavior while removing per-cookie allocations

## Testing
- `pnpm test -- SafariCookieQueryStrategy.dates.test.ts`
- `pnpm run type-check`
- `pnpm exec biome check src/core/browsers/safari/BinaryCodableCookie.ts`

## Notes
- the local Husky hooks expect the exact `.nvmrc` version (`22.0.0`); this environment used Node `22.22.2`, which is still within the package `engines` range, so the checks above were run manually before commit and push.

Closes #535