### PR TITLE
perf(chrome): derive PBKDF2 key once per password not per cookie

### DIFF
--- a/src/core/browsers/chrome/__tests__/decrypt.test.ts
+++ b/src/core/browsers/chrome/__tests__/decrypt.test.ts
@@ -29,4 +29,51 @@ describe("decrypt", () => {
       await expect(decrypt(input.value, input.password)).rejects.toThrow(error);
     });
   });
+
+  // Regression coverage for the per-password derived-key cache. The derivation
+  // is memoized, so the risk is a corrupt or shared-promise cache returning the
+  // wrong key. Repeated and concurrent calls must still produce identical,
+  // correct plaintext.
+  describe("derived-key caching", () => {
+    it("produces identical output across many repeated decryptions", async () => {
+      const encryptedValue = Buffer.from(
+        TEST_COOKIES.logged_in.encrypted,
+        "hex",
+      );
+      const baseline = await decrypt(encryptedValue, TEST_PASSWORD);
+
+      const results = await Promise.all(
+        Array.from({ length: 25 }, () =>
+          decrypt(encryptedValue, TEST_PASSWORD),
+        ),
+      );
+
+      for (const result of results) {
+        expect(result).toBe(baseline);
+        expect(result).toBe(TEST_COOKIES.logged_in.decrypted);
+      }
+    });
+
+    it("decrypts every cookie correctly when run concurrently on a shared password", async () => {
+      const results = await Promise.all(
+        Object.entries(TEST_COOKIES).map(async ([, cookie]) => ({
+          cookie,
+          decrypted: await decrypt(
+            Buffer.from(cookie.encrypted, "hex"),
+            TEST_PASSWORD,
+          ),
+        })),
+      );
+
+      for (const { cookie, decrypted } of results) {
+        if ("contains" in cookie) {
+          for (const value of cookie.contains) {
+            expect(decrypted).toContain(value);
+          }
+        } else {
+          expect(decrypted).toBe(cookie.decrypted);
+        }
+      }
+    });
+  });
 });

--- a/src/core/browsers/chrome/decrypt.ts
+++ b/src/core/browsers/chrome/decrypt.ts
@@ -118,6 +118,50 @@ function extractValue(decodedString: string): string {
 }
 
 /**
+ * Cache of derived AES keys, keyed by the source password string.
+ *
+ * Chrome's key derivation is a pure function of the password: the salt
+ * ("saltysalt"), iteration count (1003), key length (16) and digest (sha1) are
+ * all constant, so the same password always yields the same 16-byte key.
+ * Re-running PBKDF2 (1003 HMAC-SHA1 rounds) for every cookie is wasted work —
+ * memoizing collapses it to a single derivation per distinct password.
+ *
+ * The in-flight Promise (not the resolved Buffer) is cached so that concurrent
+ * callers coalesce onto one derivation. A rejected derivation is evicted so a
+ * transient failure cannot poison subsequent lookups.
+ */
+const derivedKeyCache = new Map<string, Promise<Buffer>>();
+
+/**
+ * Derives (or returns a cached) AES-128 key from a Chrome password via PBKDF2.
+ * @param password - The Chrome encryption password
+ * @returns A promise resolving to the 16-byte derived key
+ */
+function deriveKey(password: string): Promise<Buffer> {
+  const cached = derivedKeyCache.get(password);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  const keyPromise = new Promise<Buffer>((resolve, reject) => {
+    pbkdf2(password, "saltysalt", 1003, 16, "sha1", (error, key) => {
+      if (error) {
+        reject(new Error(`Failed to derive key: ${error.message}`));
+        return;
+      }
+      resolve(key);
+    });
+  }).catch((error: unknown) => {
+    // Don't cache failures — let the next call retry from scratch.
+    derivedKeyCache.delete(password);
+    throw error;
+  });
+
+  derivedKeyCache.set(password, keyPromise);
+  return keyPromise;
+}
+
+/**
  * Decrypts Chrome's encrypted cookie values
  * @param encryptedValue - The encrypted cookie value as a Buffer
  * @param password - The Chrome encryption password
@@ -165,51 +209,46 @@ export async function decrypt(
     throw new Error("encryptedData must be a Buffer");
   }
 
-  return new Promise((resolve, reject) => {
-    pbkdf2(password, "saltysalt", 1003, 16, "sha1", (error, key) => {
-      try {
-        if (error) {
-          reject(new Error(`Failed to derive key: ${error.message}`));
-          return;
-        }
+  // Derive the AES key once per password (cached); see deriveKey above.
+  const key = await deriveKey(password);
 
-        const value = removeV10Prefix(encryptedValue);
-        if (value.length % 16 !== 0) {
-          reject(new Error("Encrypted data length is not a multiple of 16"));
-          return;
-        }
+  const value = removeV10Prefix(encryptedValue);
+  if (value.length % 16 !== 0) {
+    throw new Error("Encrypted data length is not a multiple of 16");
+  }
 
-        // Chrome's encryption parameters
-        const iv = Buffer.alloc(16, " "); // 16 spaces
-        const decipher = createDecipheriv("aes-128-cbc", key, iv);
-        decipher.setAutoPadding(false);
+  try {
+    // Chrome's encryption parameters
+    const iv = Buffer.alloc(16, " "); // 16 spaces
+    const decipher = createDecipheriv("aes-128-cbc", key, iv);
+    decipher.setAutoPadding(false);
 
-        // Decrypt the value
-        let decrypted: Buffer = decipher.update(value);
-        try {
-          decipher.final();
-        } catch (e) {
-          reject(
-            new Error(`Failed to finalize decryption: ${(e as Error).message}`),
-          );
-          return;
-        }
+    // Decrypt the value
+    let decrypted: Buffer = decipher.update(value);
+    try {
+      decipher.final();
+    } catch (e) {
+      throw new Error(`Failed to finalize decryption: ${(e as Error).message}`);
+    }
 
-        decrypted = removePadding(decrypted);
+    decrypted = removePadding(decrypted);
 
-        // Skip the first 32 bytes (hash prefix) if meta version >= 24
-        // Ref: https://chromium.googlesource.com/chromium/src/+/b02dcebd7cafab92770734dc2bc317bd07f1d891/net/extras/sqlite/sqlite_persistent_cookie_store.cc#223
-        const useHashPrefix = (metaVersion ?? 0) >= 24;
-        const finalDecrypted =
-          useHashPrefix && decrypted.length > 32
-            ? decrypted.slice(32)
-            : decrypted;
+    // Skip the first 32 bytes (hash prefix) if meta version >= 24
+    // Ref: https://chromium.googlesource.com/chromium/src/+/b02dcebd7cafab92770734dc2bc317bd07f1d891/net/extras/sqlite/sqlite_persistent_cookie_store.cc#223
+    const useHashPrefix = (metaVersion ?? 0) >= 24;
+    const finalDecrypted =
+      useHashPrefix && decrypted.length > 32 ? decrypted.slice(32) : decrypted;
 
-        const decodedString = finalDecrypted.toString("utf8");
-        resolve(extractValue(decodedString));
-      } catch (e) {
-        reject(new Error(`Decryption failed: ${(e as Error).message}`));
-      }
-    });
-  });
+    const decodedString = finalDecrypted.toString("utf8");
+    return extractValue(decodedString);
+  } catch (e) {
+    // Preserve the specific finalize-failure message; wrap anything else.
+    if (
+      e instanceof Error &&
+      e.message.startsWith("Failed to finalize decryption")
+    ) {
+      throw e;
+    }
+    throw new Error(`Decryption failed: ${(e as Error).message}`);
+  }
 }


### PR DESCRIPTION
## Summary

Closes #532.

Chrome cookie decryption re-ran PBKDF2 (1003 HMAC-SHA1 rounds) **inside the per-cookie `decrypt()` promise** (`src/core/browsers/chrome/decrypt.ts:169`). The salt (`saltysalt`), iteration count (1003), key length (16) and digest (sha1) are all constant, so the derived 16-byte key is a pure function of the password — it was being recomputed identically for every cookie in a query.

## Change

- Added a module-level `Map<string, Promise<Buffer>>` (`derivedKeyCache`) memoizing the derived key by password.
- The **in-flight promise** is cached so concurrent callers coalesce onto a single derivation.
- A **rejected derivation is evicted** so a transient failure cannot poison subsequent lookups.
- Refactored `decrypt()` from the PBKDF2-callback Promise to `await deriveKey(password)`, preserving every existing rejection message exactly.

## Verification

- Output is **byte-identical** — existing `decrypt.test.ts` cases still assert `.toBe(cookie.decrypted)` and pass.
- Both `ERROR_CASES` still reject with their exact messages.
- Added regression coverage: repeated (×25) and concurrent decryptions on a shared password all produce identical, correct plaintext.
- `bun test … decrypt.test.ts` → **9 pass / 64 expect()**; `biome check` clean; husky pre-commit (Node 22 via `.nvmrc`) ran typecheck + lint-staged.

## Part of a farmed-out batch

First of four optimizations found comparing against the Rust sibling `get-cookie2`: #532 (this PR), #533 (keychain password memoization), #534 (parallel per-profile reads), #535 (Safari buffer reads, addressed in PR #536). Each ships as its own PR.