### PR TITLE
perf(chromium): memoize Safe Storage keychain password per browser

### DIFF
--- a/src/core/browsers/chrome/__tests__/getChromiumPassword.test.ts
+++ b/src/core/browsers/chrome/__tests__/getChromiumPassword.test.ts
@@ -1,0 +1,44 @@
+import {
+  getChromiumPassword,
+  resetChromiumPasswordCache,
+} from "../getChromiumPassword";
+
+describe("getChromiumPassword caching", () => {
+  beforeEach(() => {
+    resetChromiumPasswordCache();
+  });
+
+  afterEach(() => {
+    resetChromiumPasswordCache();
+  });
+
+  it("coalesces concurrent callers onto a single cached lookup", async () => {
+    const first = getChromiumPassword("chrome");
+    const second = getChromiumPassword("chrome");
+
+    // Same in-flight promise returned => only one underlying lookup runs.
+    expect(second).toBe(first);
+
+    // Settle without surfacing rejections in environments without a keychain.
+    await Promise.allSettled([first, second]);
+  });
+
+  it("keys the cache per browser", async () => {
+    const chrome = getChromiumPassword("chrome");
+    const brave = getChromiumPassword("brave");
+
+    expect(brave).not.toBe(chrome);
+
+    await Promise.allSettled([chrome, brave]);
+  });
+
+  it("performs a fresh lookup after the cache is reset", async () => {
+    const before = getChromiumPassword("chrome");
+    resetChromiumPasswordCache();
+    const after = getChromiumPassword("chrome");
+
+    expect(after).not.toBe(before);
+
+    await Promise.allSettled([before, after]);
+  });
+});

--- a/src/core/browsers/chrome/getChromiumPassword.ts
+++ b/src/core/browsers/chrome/getChromiumPassword.ts
@@ -73,15 +73,12 @@ async function getLinuxPassword(): Promise<string> {
 }
 
 /**
- * Gets the Chromium-based browser Safe Storage password for the current platform.
- * This password is used to decrypt cookies stored in the browser's cookie database.
- * Supports macOS (keychain), Windows (DPAPI), and Linux (keyring/libsecret).
+ * Resolves the Safe Storage password by dispatching to the platform backend.
  * @param browser - The Chromium-based browser to get the password for
  * @returns A promise that resolves to the browser's Safe Storage password or Buffer
- * @throws {Error} If the password cannot be retrieved or the platform is not supported
  */
-export async function getChromiumPassword(
-  browser: ChromiumBrowser = "chrome",
+async function resolveChromiumPassword(
+  browser: ChromiumBrowser,
 ): Promise<string | Buffer> {
   assertPlatformSupported();
 
@@ -100,4 +97,59 @@ export async function getChromiumPassword(
     default:
       throw new Error(`Platform ${getPlatform()} is not supported`);
   }
+}
+
+/**
+ * Per-browser cache of the Safe Storage password.
+ *
+ * The Safe Storage secret is stable for the lifetime of the process, but each
+ * lookup is expensive: macOS spawns the `security` subprocess and Windows/Linux
+ * dynamically import a platform module. The same password is requested per
+ * cookie file, per profile and across Chromium-family strategies, so without a
+ * cache a single run pays that cost many times over.
+ *
+ * The in-flight Promise (not the resolved value) is cached so concurrent
+ * callers coalesce onto one lookup. Failures are evicted so a transient error
+ * (e.g. keychain locked) does not poison later retries — only successful
+ * lookups stay cached.
+ */
+const passwordCache = new Map<ChromiumBrowser, Promise<string | Buffer>>();
+
+/**
+ * Gets the Chromium-based browser Safe Storage password for the current platform.
+ * This password is used to decrypt cookies stored in the browser's cookie database.
+ * Supports macOS (keychain), Windows (DPAPI), and Linux (keyring/libsecret).
+ *
+ * The result is memoized per browser for the process lifetime; see
+ * {@link resetChromiumPasswordCache} to clear it in tests.
+ * @param browser - The Chromium-based browser to get the password for
+ * @returns A promise that resolves to the browser's Safe Storage password or Buffer
+ * @throws {Error} If the password cannot be retrieved or the platform is not supported
+ */
+export function getChromiumPassword(
+  browser: ChromiumBrowser = "chrome",
+): Promise<string | Buffer> {
+  const cached = passwordCache.get(browser);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  const passwordPromise = resolveChromiumPassword(browser).catch(
+    (error: unknown) => {
+      // Don't cache failures — let the next call retry the keychain/import.
+      passwordCache.delete(browser);
+      throw error;
+    },
+  );
+
+  passwordCache.set(browser, passwordPromise);
+  return passwordPromise;
+}
+
+/**
+ * Clears the cached Safe Storage passwords. Intended for tests that need to
+ * exercise password retrieval in isolation without cross-test cache bleed.
+ */
+export function resetChromiumPasswordCache(): void {
+  passwordCache.clear();
 }


### PR DESCRIPTION
## Summary

Closes #533.

`getChromiumPassword()` had **no caching**: every call re-fetched the Safe Storage secret — on macOS spawning `security find-generic-password` (`src/core/browsers/chrome/getChromiumPassword.ts:34`), on Windows/Linux dynamically importing the platform module and re-deriving. The same password is requested per cookie file, per profile and across Chromium-family strategies, so a single run paid that subprocess/import cost many times over.

## Change

- Added a module-level `Map<ChromiumBrowser, Promise<string | Buffer>>` (`passwordCache`) memoizing the password per browser for the process lifetime.
- Converted `getChromiumPassword` from `async` to a plain wrapper that returns the **cached in-flight promise** — so concurrent callers coalesce onto a single lookup (an `async` function would re-wrap and defeat identity-based coalescing). The platform dispatch moved to an extracted `resolveChromiumPassword` helper.
- **Failures are evicted** (`.catch` deletes the cache entry and rethrows) so a transient keychain error can't poison later retries — only successful lookups stay cached. The Chrome-fallback path for non-Chrome browsers is preserved inside `getMacOSPassword`.
- Added a test-only `resetChromiumPasswordCache()` hook.

## Verification

- New `getChromiumPassword.test.ts`: asserts concurrent callers get the same cached promise (coalescing), the cache is keyed per browser, and a reset forces a fresh lookup — **3 pass** via bun, runs under jest too.
- `cross-platform.test.ts` integration suite still **10 pass / 2 skip / 0 fail**.
- `biome check` clean; husky pre-commit (Node 22 via `.nvmrc`) ran typecheck + lint-staged.

## Part of a farmed-out batch

Pairs with #532 (PR #537): together they collapse (N cookies × M profiles) crypto+keychain work to one keychain read + one PBKDF2 per distinct password. Remaining: #534 (parallel per-profile reads), #535 (Safari buffer reads — PR #536).