### PR TITLE
refactor(browsers): remove stale stderr redirects from version commands

### DIFF
--- a/src/core/browsers/BrowserAvailability.ts
+++ b/src/core/browsers/BrowserAvailability.ts
@@ -367,37 +367,31 @@ function getVersionCommand(browser: BrowserType): string | undefined {
   if (isMacOS()) {
     const versionCommands: Partial<Record<BrowserType, string>> = {
       chrome:
-        "/Applications/Google\\ Chrome.app/Contents/MacOS/Google\\ Chrome --version 2>/dev/null",
-      firefox:
-        "/Applications/Firefox.app/Contents/MacOS/firefox --version 2>/dev/null",
+        "/Applications/Google\\ Chrome.app/Contents/MacOS/Google\\ Chrome --version",
+      firefox: "/Applications/Firefox.app/Contents/MacOS/firefox --version",
       safari:
-        "defaults read /Applications/Safari.app/Contents/Info.plist CFBundleShortVersionString 2>/dev/null",
-      edge: "/Applications/Microsoft\\ Edge.app/Contents/MacOS/Microsoft\\ Edge --version 2>/dev/null",
-      arc: "defaults read /Applications/Arc.app/Contents/Info.plist CFBundleShortVersionString 2>/dev/null",
+        "defaults read /Applications/Safari.app/Contents/Info.plist CFBundleShortVersionString",
+      edge: "/Applications/Microsoft\\ Edge.app/Contents/MacOS/Microsoft\\ Edge --version",
+      arc: "defaults read /Applications/Arc.app/Contents/Info.plist CFBundleShortVersionString",
       brave:
-        "/Applications/Brave\\ Browser.app/Contents/MacOS/Brave\\ Browser --version 2>/dev/null",
-      opera:
-        "/Applications/Opera.app/Contents/MacOS/Opera --version 2>/dev/null",
+        "/Applications/Brave\\ Browser.app/Contents/MacOS/Brave\\ Browser --version",
+      opera: "/Applications/Opera.app/Contents/MacOS/Opera --version",
       "opera-gx":
-        "/Applications/Opera\\ GX.app/Contents/MacOS/Opera\\ GX --version 2>/dev/null",
-      vivaldi:
-        "/Applications/Vivaldi.app/Contents/MacOS/Vivaldi --version 2>/dev/null",
+        "/Applications/Opera\\ GX.app/Contents/MacOS/Opera\\ GX --version",
+      vivaldi: "/Applications/Vivaldi.app/Contents/MacOS/Vivaldi --version",
     };
     return versionCommands[browser];
   }
 
   if (isLinux()) {
     const versionCommands: Partial<Record<BrowserType, string>> = {
-      chrome:
-        "google-chrome --version 2>/dev/null || google-chrome-stable --version 2>/dev/null",
-      firefox: "firefox --version 2>/dev/null",
-      edge: "microsoft-edge --version 2>/dev/null",
-      brave:
-        "brave-browser --version 2>/dev/null || brave-browser-stable --version 2>/dev/null",
-      opera: "opera --version 2>/dev/null",
-      "opera-gx": "opera-gx --version 2>/dev/null",
-      vivaldi:
-        "vivaldi --version 2>/dev/null || vivaldi-stable --version 2>/dev/null",
+      chrome: "google-chrome --version || google-chrome-stable --version",
+      firefox: "firefox --version",
+      edge: "microsoft-edge --version",
+      brave: "brave-browser --version || brave-browser-stable --version",
+      opera: "opera --version",
+      "opera-gx": "opera-gx --version",
+      vivaldi: "vivaldi --version || vivaldi-stable --version",
     };
     return versionCommands[browser];
   }

--- a/src/core/browsers/__tests__/BrowserAvailability.version.test.ts
+++ b/src/core/browsers/__tests__/BrowserAvailability.version.test.ts
@@ -143,6 +143,33 @@ describe("getBrowserVersionAsync", () => {
     });
   });
 
+  describe("command hygiene", () => {
+    it("does not embed shell stderr redirects in macOS commands", async () => {
+      setMacOS();
+      mockExecSimple.mockResolvedValueOnce({ stdout: "x\n", stderr: "" });
+
+      await getBrowserVersionAsync("chrome");
+
+      const command = mockExecSimple.mock.calls[0]?.[0] ?? "";
+      expect(command).toContain("--version");
+      // execSimple captures stderr separately, so the redirect is redundant.
+      expect(command).not.toContain("2>/dev/null");
+    });
+
+    it("does not embed redirects but keeps the || fallback on Linux", async () => {
+      setLinux();
+      mockExecSimple.mockResolvedValueOnce({ stdout: "y\n", stderr: "" });
+
+      await getBrowserVersionAsync("chrome");
+
+      const command = mockExecSimple.mock.calls[0]?.[0] ?? "";
+      expect(command).not.toContain("2>/dev/null");
+      // The || fallback to the -stable binary must survive the cleanup.
+      expect(command).toContain("||");
+      expect(command).toContain("google-chrome-stable --version");
+    });
+  });
+
   describe("failure modes", () => {
     it("returns undefined when execSimple rejects", async () => {
       mockExecSimple.mockRejectedValueOnce(new Error("ENOENT"));


### PR DESCRIPTION
## Summary

`getVersionCommand()` embedded `2>/dev/null` shell stderr redirects in every browser version command string. They were redundant: `execSimple` captures `stdout` and `stderr` separately, and `getBrowserVersionAsync()` reads only `stdout` and wraps the whole call in try/catch — so stderr never influenced the result and a non-zero exit is already handled.

This strips all 15 redirects from the macOS and Linux command tables while preserving the Linux `||` fallbacks (`cmd1 --version || cmd2 --version`), whose short-circuit keys off the exit code, not the redirect.

## Changes
- `BrowserAvailability.ts`: remove `2>/dev/null` from macOS + Linux `getVersionCommand()` strings.
- `BrowserAvailability.version.test.ts`: add a `command hygiene` suite asserting commands contain no redirect and the Linux `||` fallback survives.

## Verification
- type-check: clean
- lint (biome): clean, 224 files
- tests: 67/67 pass in `src/core/browsers/__tests__/` (11 in the version suite, incl. 2 new guards)

Closes #514