### PR TITLE
refactor(cookies): widen queryCookies default strategy annotation

### DIFF
--- a/src/core/cookies/queryCookies.ts
+++ b/src/core/cookies/queryCookies.ts
@@ -1,10 +1,11 @@
 import type { CookieSpec, ExportedCookie } from "../../types/schemas";
+import type { BaseCookieQueryStrategy } from "../browsers/BaseCookieQueryStrategy";
 import { ChromeCookieQueryStrategy } from "../browsers/chrome/ChromeCookieQueryStrategy";
 import { FirefoxCookieQueryStrategy } from "../browsers/firefox/FirefoxCookieQueryStrategy";
 import { SafariCookieQueryStrategy } from "../browsers/safari/SafariCookieQueryStrategy";
 
 /** Reusable default strategy instances — stateless after construction */
-const defaultStrategies = [
+const defaultStrategies: BaseCookieQueryStrategy[] = [
   new ChromeCookieQueryStrategy(),
   new FirefoxCookieQueryStrategy(),
   new SafariCookieQueryStrategy(),


### PR DESCRIPTION
## Summary

`queryCookies.ts` relied on TypeScript inferring `defaultStrategies` as a concrete union array, whereas the sibling `batchQueryCookies.ts` already annotates the identical list as `BaseCookieQueryStrategy[]`. This aligns the two modules.

## Changes
- Add a type-only import of `BaseCookieQueryStrategy`.
- Annotate `defaultStrategies` as `BaseCookieQueryStrategy[]` — documents the abstraction boundary; no runtime change.

## Verification
- type-check: clean
- lint (biome): clean, 224 files
- tests: 61 passed / 2 skipped in `src/core/cookies/__tests__/`

Closes #517