### PR TITLE
docs(cookies): clarify singleton strategy state assumptions

### DIFF
--- a/src/core/cookies/batchQueryCookies.ts
+++ b/src/core/cookies/batchQueryCookies.ts
@@ -6,7 +6,14 @@ import { ChromeCookieQueryStrategy } from "../browsers/chrome/ChromeCookieQueryS
 import { FirefoxCookieQueryStrategy } from "../browsers/firefox/FirefoxCookieQueryStrategy";
 import { SafariCookieQueryStrategy } from "../browsers/safari/SafariCookieQueryStrategy";
 
-/** Reusable default strategy instances — stateless after construction */
+/**
+ * Reusable default strategy instances, shared across every batch query.
+ * Safe only because each strategy is stateless after construction: a query
+ * threads its own arguments through and accumulates no per-invocation state.
+ * If a strategy (or a collaborator such as `BrowserLockHandler`) ever starts
+ * holding per-call mutable state, this shared singleton would leak it across
+ * callers — revisit the singleton choice rather than reuse instances then.
+ */
 const defaultStrategies: BaseCookieQueryStrategy[] = [
   new ChromeCookieQueryStrategy(),
   new FirefoxCookieQueryStrategy(),

--- a/src/core/cookies/comboQueryCookieSpec.ts
+++ b/src/core/cookies/comboQueryCookieSpec.ts
@@ -10,7 +10,12 @@ import { FirefoxCookieQueryStrategy } from "../browsers/firefox/FirefoxCookieQue
 import { SafariCookieQueryStrategy } from "../browsers/safari/SafariCookieQueryStrategy";
 
 /**
- * Reusable default composite strategy — stateless after construction.
+ * Reusable default composite strategy, shared across every call.
+ * Safe only because the composed strategies are stateless after construction:
+ * each query threads its own arguments through and accumulates no per-call
+ * state. If any composed strategy (or a collaborator such as
+ * `BrowserLockHandler`) starts holding per-invocation state, this shared
+ * singleton would leak it across callers — revisit the singleton choice then.
  * @internal Not part of the public API. Callers needing a custom strategy
  * should pass `options.strategy` to {@link comboQueryCookieSpec}.
  */

--- a/src/core/cookies/queryCookies.ts
+++ b/src/core/cookies/queryCookies.ts
@@ -4,7 +4,14 @@ import { ChromeCookieQueryStrategy } from "../browsers/chrome/ChromeCookieQueryS
 import { FirefoxCookieQueryStrategy } from "../browsers/firefox/FirefoxCookieQueryStrategy";
 import { SafariCookieQueryStrategy } from "../browsers/safari/SafariCookieQueryStrategy";
 
-/** Reusable default strategy instances — stateless after construction */
+/**
+ * Reusable default strategy instances, shared across every `queryCookies` call.
+ * Safe only because each strategy is stateless after construction: a query
+ * threads its own arguments through and accumulates no per-invocation state.
+ * If a strategy (or a collaborator such as `BrowserLockHandler`) ever starts
+ * holding per-call mutable state, this shared singleton would leak it across
+ * callers — revisit the singleton choice rather than reuse instances then.
+ */
 const defaultStrategies: BaseCookieQueryStrategy[] = [
   new ChromeCookieQueryStrategy(),
   new FirefoxCookieQueryStrategy(),


### PR DESCRIPTION
## Summary

The module-level default-strategy singletons in the cookie query helpers were documented only as "stateless after construction," which did not capture *why* sharing a single instance across every call is safe. This expands the comments to make the invariant explicit.

## Changes
Expanded the singleton TSDoc in:
- `queryCookies.ts`
- `batchQueryCookies.ts`
- `comboQueryCookieSpec.ts`

Each now states the instance is shared across every call, and that this is safe only while the strategies (and collaborators like `BrowserLockHandler`) hold no per-invocation mutable state — otherwise the shared singleton would leak state across callers and the singleton choice should be revisited.

## Verification
- lint (biome): clean, 224 files
- type-check: clean
- Comment-only change; no behavioral impact, no test changes needed.

Closes #518