### PR TITLE
perf(safari): avoid buffer copy when decoding cookie timestamps

### DIFF
--- a/src/core/browsers/safari/BinaryCodableCookie.ts
+++ b/src/core/browsers/safari/BinaryCodableCookie.ts
@@ -374,19 +374,11 @@ export class BinaryCodableCookie {
    */
   private readTimestamps(container: BinaryCodableContainer): void {
     // Read expiration time (8 bytes, little-endian double)
-    const expirationBuffer = Buffer.alloc(8);
-    for (let i = 0; i < 8; i++) {
-      expirationBuffer[i] = container.buffer[container.offset + i]!;
-    }
-    const expiration = expirationBuffer.readDoubleLE(0);
+    const expiration = container.buffer.readDoubleLE(container.offset);
     container.offset += 8;
 
     // Read creation time (8 bytes, little-endian double)
-    const creationBuffer = Buffer.alloc(8);
-    for (let i = 0; i < 8; i++) {
-      creationBuffer[i] = container.buffer[container.offset + i]!;
-    }
-    const creation = creationBuffer.readDoubleLE(0);
+    const creation = container.buffer.readDoubleLE(container.offset);
     container.offset += 8;
 
     // Store raw timestamps (seconds since 2001-01-01)


### PR DESCRIPTION
## Summary

`BinaryCodableCookie.readTimestamps` allocated an 8-byte scratch `Buffer` and copied the source bytes one at a time before calling `readDoubleLE(0)` — once for the expiration timestamp and again for the creation timestamp. `Buffer.readDoubleLE(offset)` reads the 8-byte little-endian double in place, so the scratch allocation and byte loop were redundant.

This reads both timestamps directly from the source buffer at `container.offset`, removing two per-cookie heap allocations and 16 byte-copies. Behaviour is unchanged for well-formed records; a truncated record now throws (consistent with the `readUInt32LE` header reads that already run for the same record) instead of silently zero-filling.

## Verification
- Safari suite: 77/77 pass (`src/core/browsers/safari/`)
- lint (biome): clean, 224 files
- type-check: clean

Closes #535