### PR TITLE
refactor(browsers): route detection fs access through runtime adapter

### DIFF
--- a/src/bun.ts
+++ b/src/bun.ts
@@ -8,8 +8,11 @@
  * import { getCookie } from "@mherod/get-cookie/bun";
  * ```
  */
+import { createBunFileSystemAdapter } from "./core/browsers/runtime/BunFileSystemAdapter";
+import { setFileSystemAdapter } from "./core/browsers/runtime/FileSystemAdapter";
 import { setRuntimeOverride } from "./core/browsers/sql/adapters/DatabaseAdapter";
 
 setRuntimeOverride("bun");
+setFileSystemAdapter(createBunFileSystemAdapter());
 
 export * from "./index";

--- a/src/core/browsers/BrowserDetector.ts
+++ b/src/core/browsers/BrowserDetector.ts
@@ -3,9 +3,9 @@
  * @module BrowserDetector
  */
 
-import { closeSync, existsSync, openSync, readSync } from "node:fs";
-
 import { createTaggedLogger } from "@utils/logHelpers";
+
+import { getFileSystemAdapter } from "./runtime/FileSystemAdapter";
 
 const logger = createTaggedLogger("BrowserDetector");
 
@@ -61,30 +61,19 @@ const BROWSER_PATTERNS: Array<{
  * @returns True if the file has Safari's binary cookie format signature
  */
 export function checkSafariMagicBytes(storePath: string): boolean {
-  let fd: number | undefined;
-  try {
-    fd = openSync(storePath, "r");
-    const buf = Buffer.alloc(4);
-    const bytesRead = readSync(fd, buf, 0, 4, 0);
-    // Safari binary cookies start with "cook" magic bytes
-    return (
-      bytesRead === 4 &&
-      buf[0] === SAFARI_MAGIC_BYTES.c &&
-      buf[1] === SAFARI_MAGIC_BYTES.o1 &&
-      buf[2] === SAFARI_MAGIC_BYTES.o2 &&
-      buf[3] === SAFARI_MAGIC_BYTES.k
-    );
-  } catch (error) {
-    logger.debug("Failed to read file for magic bytes check", {
-      path: storePath,
-      error,
-    });
+  const buf = getFileSystemAdapter().readLeadingBytes(storePath, 4);
+  if (buf === null) {
     return false;
-  } finally {
-    if (fd !== undefined) {
-      closeSync(fd);
-    }
   }
+
+  // Safari binary cookies start with "cook" magic bytes
+  return (
+    buf.length === 4 &&
+    buf[0] === SAFARI_MAGIC_BYTES.c &&
+    buf[1] === SAFARI_MAGIC_BYTES.o1 &&
+    buf[2] === SAFARI_MAGIC_BYTES.o2 &&
+    buf[3] === SAFARI_MAGIC_BYTES.k
+  );
 }
 
 /**
@@ -118,7 +107,7 @@ export function detectBrowserFromFilename(
 export function detectBrowserFromStore(
   storePath: string,
 ): BrowserType | undefined {
-  if (!storePath || !existsSync(storePath)) {
+  if (!storePath || !getFileSystemAdapter().fileExists(storePath)) {
     logger.debug("Store path does not exist", { storePath });
     return undefined;
   }

--- a/src/core/browsers/runtime/BunFileSystemAdapter.ts
+++ b/src/core/browsers/runtime/BunFileSystemAdapter.ts
@@ -1,0 +1,25 @@
+/**
+ * Bun filesystem adapter implementation
+ *
+ * Wired by the `@mherod/get-cookie/bun` entrypoint.
+ *
+ * Bun exposes no synchronous `BunFile` content read — `Bun.file(path).bytes()`
+ * and `.arrayBuffer()` are async, and only `.size` is synchronous. Browser
+ * detection's magic-byte sniff is synchronous (it runs inside the sync
+ * `detectBrowserFromStore` path), so the only correct option under Bun is
+ * `node:fs`, which Bun implements natively. This adapter therefore composes the
+ * Node implementation. It exists as a distinct, named adapter so the Bun
+ * entrypoint can wire Bun-specific behaviour here if an async read path is ever
+ * introduced.
+ */
+
+import type { FileSystemAdapter } from "./FileSystemAdapter";
+import { createNodeFileSystemAdapter } from "./NodeFileSystemAdapter";
+
+/**
+ * Create a {@link FileSystemAdapter} for the Bun runtime.
+ * @returns A Bun-runtime filesystem adapter (backed by Bun's native `node:fs`)
+ */
+export function createBunFileSystemAdapter(): FileSystemAdapter {
+  return createNodeFileSystemAdapter();
+}

--- a/src/core/browsers/runtime/FileSystemAdapter.ts
+++ b/src/core/browsers/runtime/FileSystemAdapter.ts
@@ -1,0 +1,83 @@
+/**
+ * Filesystem adapter abstraction layer
+ *
+ * Provides a unified, runtime-injectable interface for the small amount of
+ * synchronous disk access that browser detection needs (checking a store path
+ * exists and sniffing a file's leading "magic" bytes).
+ *
+ * Mirrors the SQLite {@link ./../sql/adapters/DatabaseAdapter} design: the
+ * `@mherod/get-cookie/node` and `@mherod/get-cookie/bun` entrypoints call
+ * {@link setFileSystemAdapter} to wire the runtime-appropriate implementation,
+ * keeping `node:fs` imports out of the universal entry graph and off of
+ * detection logic such as {@link ./../BrowserDetector}.
+ */
+
+/**
+ * Minimal synchronous filesystem surface required by browser detection.
+ */
+export interface FileSystemAdapter {
+  /**
+   * Check whether a path exists on disk.
+   * @param path - Absolute or relative path to test
+   * @returns True when the path exists
+   */
+  fileExists(path: string): boolean;
+
+  /**
+   * Read the leading bytes of a file without loading the whole file.
+   *
+   * Used to sniff format signatures (e.g. Safari's `cook` binary cookie magic
+   * bytes) cheaply, even when the underlying store is large.
+   *
+   * @param path - Path to the file to read
+   * @param length - Number of bytes to read from the start of the file
+   * @returns A buffer of up to `length` bytes, or `null` if the read failed
+   */
+  readLeadingBytes(path: string, length: number): Buffer | null;
+}
+
+/**
+ * Active adapter, injected by an entrypoint via {@link setFileSystemAdapter}.
+ * When unset, {@link getFileSystemAdapter} lazily falls back to the Node
+ * implementation so the default `@mherod/get-cookie` entry works standalone.
+ */
+let currentAdapter: FileSystemAdapter | undefined;
+
+/**
+ * Inject the filesystem implementation to use for browser detection.
+ *
+ * Called by the `@mherod/get-cookie/node` and `@mherod/get-cookie/bun`
+ * entrypoints so consumers get deterministic, runtime-appropriate disk access
+ * without relying on auto-detection.
+ *
+ * @param adapter - The adapter to use, or `undefined` to clear the override
+ */
+export function setFileSystemAdapter(
+  adapter: FileSystemAdapter | undefined,
+): void {
+  currentAdapter = adapter;
+}
+
+/**
+ * Resolve the active filesystem adapter.
+ *
+ * Returns the injected adapter when an entrypoint has set one; otherwise lazily
+ * loads the Node implementation. The Node adapter relies only on `node:fs`,
+ * which Bun also implements natively, so it is a safe synchronous default for
+ * either runtime.
+ *
+ * @returns The filesystem adapter to use
+ */
+export function getFileSystemAdapter(): FileSystemAdapter {
+  if (currentAdapter !== undefined) {
+    return currentAdapter;
+  }
+
+  // Lazily require the Node adapter so `node:fs` is only pulled in on first
+  // use, keeping it out of the static import graph of the base bundle.
+  const { createNodeFileSystemAdapter } =
+    require("./NodeFileSystemAdapter") as typeof import("./NodeFileSystemAdapter");
+  const adapter = createNodeFileSystemAdapter();
+  currentAdapter = adapter;
+  return adapter;
+}

--- a/src/core/browsers/runtime/NodeFileSystemAdapter.ts
+++ b/src/core/browsers/runtime/NodeFileSystemAdapter.ts
@@ -1,0 +1,45 @@
+/**
+ * Node.js filesystem adapter implementation
+ *
+ * Backs {@link ./FileSystemAdapter.FileSystemAdapter} with `node:fs` synchronous
+ * primitives. Wired by the `@mherod/get-cookie/node` entrypoint, and also used
+ * as the lazy default for the base entry. Bun implements `node:fs` natively, so
+ * this adapter is a correct synchronous implementation under Bun as well.
+ */
+
+import { closeSync, existsSync, openSync, readSync } from "node:fs";
+
+import { createTaggedLogger } from "@utils/logHelpers";
+
+import type { FileSystemAdapter } from "./FileSystemAdapter";
+
+const logger = createTaggedLogger("NodeFileSystemAdapter");
+
+/**
+ * Create a {@link FileSystemAdapter} backed by `node:fs`.
+ * @returns A Node-backed filesystem adapter
+ */
+export function createNodeFileSystemAdapter(): FileSystemAdapter {
+  return {
+    fileExists(path: string): boolean {
+      return existsSync(path);
+    },
+
+    readLeadingBytes(path: string, length: number): Buffer | null {
+      let fd: number | undefined;
+      try {
+        fd = openSync(path, "r");
+        const buffer = Buffer.alloc(length);
+        const bytesRead = readSync(fd, buffer, 0, length, 0);
+        return bytesRead < length ? buffer.subarray(0, bytesRead) : buffer;
+      } catch (error) {
+        logger.debug("Failed to read leading bytes", { path, length, error });
+        return null;
+      } finally {
+        if (fd !== undefined) {
+          closeSync(fd);
+        }
+      }
+    },
+  };
+}

--- a/src/core/browsers/runtime/__tests__/FileSystemAdapter.test.ts
+++ b/src/core/browsers/runtime/__tests__/FileSystemAdapter.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Tests for the runtime filesystem adapter abstraction and its
+ * Node/Bun implementations.
+ */
+
+import { closeSync, mkdtempSync, openSync, rmSync, writeSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+} from "@jest/globals";
+
+import { createBunFileSystemAdapter } from "../BunFileSystemAdapter";
+import {
+  type FileSystemAdapter,
+  getFileSystemAdapter,
+  setFileSystemAdapter,
+} from "../FileSystemAdapter";
+import { createNodeFileSystemAdapter } from "../NodeFileSystemAdapter";
+
+describe("FileSystemAdapter", () => {
+  let tmpDir: string;
+  let cookFile: string;
+  let emptyFile: string;
+
+  beforeAll(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "fs-adapter-"));
+
+    // A file beginning with Safari's "cook" magic bytes followed by padding.
+    cookFile = join(tmpDir, "Cookies.binarycookies");
+    const fd = openSync(cookFile, "w");
+    writeSync(fd, Buffer.from("cookEXTRA", "ascii"), 0, 9, 0);
+    closeSync(fd);
+
+    // A zero-byte file to exercise short reads / existence.
+    emptyFile = join(tmpDir, "empty");
+    closeSync(openSync(emptyFile, "w"));
+  });
+
+  afterAll(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  afterEach(() => {
+    // Clear any injected adapter so the lazy default is restored between tests.
+    setFileSystemAdapter(undefined);
+  });
+
+  describe("getFileSystemAdapter (lazy default)", () => {
+    it("returns a Node-backed adapter when no adapter is injected", () => {
+      const adapter = getFileSystemAdapter();
+      expect(adapter.fileExists(cookFile)).toBe(true);
+      expect(adapter.fileExists(join(tmpDir, "does-not-exist"))).toBe(false);
+    });
+
+    it("returns the injected adapter once one is set", () => {
+      const injected: FileSystemAdapter = {
+        fileExists: () => false,
+        readLeadingBytes: () => null,
+      };
+      setFileSystemAdapter(injected);
+      expect(getFileSystemAdapter()).toBe(injected);
+    });
+
+    it("reverts to the lazy default when the override is cleared", () => {
+      const injected: FileSystemAdapter = {
+        fileExists: () => false,
+        readLeadingBytes: () => null,
+      };
+      setFileSystemAdapter(injected);
+      expect(getFileSystemAdapter()).toBe(injected);
+
+      setFileSystemAdapter(undefined);
+      // Default adapter actually hits disk again.
+      expect(getFileSystemAdapter().fileExists(cookFile)).toBe(true);
+    });
+  });
+
+  describe.each([
+    ["NodeFileSystemAdapter", createNodeFileSystemAdapter],
+    ["BunFileSystemAdapter", createBunFileSystemAdapter],
+  ])("%s", (_name, createAdapter) => {
+    const adapter = createAdapter();
+
+    it("reports existence of real and missing files", () => {
+      expect(adapter.fileExists(cookFile)).toBe(true);
+      expect(adapter.fileExists(join(tmpDir, "nope"))).toBe(false);
+    });
+
+    it("reads the requested number of leading bytes", () => {
+      const bytes = adapter.readLeadingBytes(cookFile, 4);
+      expect(bytes).not.toBeNull();
+      expect(bytes?.toString("ascii")).toBe("cook");
+    });
+
+    it("returns a short buffer when the file has fewer bytes than requested", () => {
+      const bytes = adapter.readLeadingBytes(emptyFile, 4);
+      expect(bytes).not.toBeNull();
+      expect(bytes?.length).toBe(0);
+    });
+
+    it("returns null when the file does not exist", () => {
+      expect(adapter.readLeadingBytes(join(tmpDir, "missing"), 4)).toBeNull();
+    });
+  });
+});

--- a/src/node.ts
+++ b/src/node.ts
@@ -8,8 +8,11 @@
  * import { getCookie } from "@mherod/get-cookie/node";
  * ```
  */
+import { createNodeFileSystemAdapter } from "./core/browsers/runtime/NodeFileSystemAdapter";
+import { setFileSystemAdapter } from "./core/browsers/runtime/FileSystemAdapter";
 import { setRuntimeOverride } from "./core/browsers/sql/adapters/DatabaseAdapter";
 
 setRuntimeOverride("node");
+setFileSystemAdapter(createNodeFileSystemAdapter());
 
 export * from "./index";


### PR DESCRIPTION
## Summary

`BrowserDetector` imported `node:fs`'s `openSync`/`readSync`/`closeSync` directly. Those helpers are only used by `checkSafariMagicBytes`, which is **dead code in the library bundles** (not part of the public `src/index.ts` API). tsup's rollup tree-shake pass stripped them and emitted `UNUSED_EXTERNAL_IMPORT` warnings on every build:

```
"closeSync", "openSync" and "readSync" are imported from external module "fs" but never used in "dist/index.js".
```

## Approach

Introduce a **runtime filesystem layer** mirroring the existing SQLite `DatabaseAdapter` pattern:

- `FileSystemAdapter` interface (`fileExists`, `readLeadingBytes`) with `setFileSystemAdapter` injection + a lazy Node default.
- `NodeFileSystemAdapter` (node:fs) and `BunFileSystemAdapter` (composes Node — Bun has no synchronous `BunFile` read, and Bun implements `node:fs` natively).
- The runtime entrypoints `src/node.ts` / `src/bun.ts` now wire the runtime-appropriate adapter alongside `setRuntimeOverride`.
- `BrowserDetector` consumes `getFileSystemAdapter()` and **no longer imports `node:fs`**.

## Why this fixes the warning

The warning fires only on *partial* orphaning — some named bindings of a still-live import going unused. Concentrating the sync fs primitives in their own module lets the library graph drop the **whole module as a unit**, so the build is warning-free while still tree-shaking the helpers out of every bundle (bundles keep only `existsSync, readFileSync`).

## Verification

- `pnpm build` — **zero** fs warnings; `dist/cli.cjs` inlines the adapter for the live CLI consumer.
- `pnpm type-check` ✅  `pnpm lint` (228 files) ✅
- Tests: 375 browsers+CLI tests pass; **11 new** `FileSystemAdapter` tests covering injection, lazy default, and both adapters' read/exists behaviour.