### PR TITLE
refactor(browsers): route browser fs access via FileSystemAdapter

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
 // Local imports - core
@@ -9,6 +8,10 @@ import {
   FIREFOX_DATA_DIRS,
 } from "@core/browsers/BrowserAvailability";
 import { parseFirefoxProfilesIni } from "@core/browsers/firefox/FirefoxCookieQueryStrategy";
+import {
+  fileExists,
+  readTextFile,
+} from "@core/browsers/runtime/FileSystemAdapter";
 import { cookieSpecsFromUrl } from "@core/cookies/cookieSpecsFromUrl";
 import { parseArgv } from "@utils/argv";
 import { getErrorMessage } from "@utils/errorUtils";
@@ -120,11 +123,11 @@ function listChromiumProfiles(browser: string, dataDir: string): void {
   try {
     const localStatePath = join(dataDir, "Local State");
 
-    if (!existsSync(localStatePath)) {
+    if (!fileExists(localStatePath)) {
       return;
     }
 
-    const localState = JSON.parse(readFileSync(localStatePath, "utf8"));
+    const localState = JSON.parse(readTextFile(localStatePath));
     const profileCache = localState.profile?.info_cache ?? {};
     const entries = Object.entries(profileCache);
 
@@ -151,7 +154,7 @@ function listFirefoxProfiles(): void {
 
   for (const dataDir of dirs) {
     const iniPath = join(dataDir, "profiles.ini");
-    if (!existsSync(iniPath)) {
+    if (!fileExists(iniPath)) {
       continue;
     }
 
@@ -204,7 +207,7 @@ function listProfiles(browser?: string): void {
   // No --browser specified: list profiles for all browsers
   const platformDirs = CHROMIUM_DATA_DIRS[process.platform] ?? {};
   for (const [name, dataDir] of Object.entries(platformDirs)) {
-    if (dataDir && existsSync(join(dataDir, "Local State"))) {
+    if (dataDir && fileExists(join(dataDir, "Local State"))) {
       listChromiumProfiles(name, dataDir);
     }
   }

--- a/src/core/browsers/BrowserAvailability.ts
+++ b/src/core/browsers/BrowserAvailability.ts
@@ -3,7 +3,6 @@
  * @module BrowserAvailability
  */
 
-import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
@@ -14,6 +13,7 @@ import { getPlatform, isLinux, isMacOS, isWindows } from "@utils/platformUtils";
 import { execSimple } from "@utils/execSimple";
 
 import { getBrowserDisplayName } from "./BrowserDetector";
+import { fileExists } from "./runtime/FileSystemAdapter";
 import type { BrowserType } from "./BrowserDetector";
 
 const logger = createTaggedLogger("BrowserAvailability");
@@ -347,7 +347,7 @@ function checkBrowserInstalled(browser: BrowserType): boolean {
   const paths = browser in platformPaths ? platformPaths[browser] : [];
 
   for (const path of paths) {
-    if (existsSync(path)) {
+    if (fileExists(path)) {
       logger.debug("Found browser installation", { browser, path });
       installCache.set(browser, true);
       return true;
@@ -433,7 +433,7 @@ export async function getBrowserVersionAsync(
  * @returns Array of profile paths found
  */
 function findChromiumProfiles(basePath: string): string[] {
-  if (!existsSync(basePath)) {
+  if (!fileExists(basePath)) {
     return [];
   }
 

--- a/src/core/browsers/chrome/windows/getChromePassword.ts
+++ b/src/core/browsers/chrome/windows/getChromePassword.ts
@@ -1,10 +1,10 @@
-import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { getErrorMessage } from "@utils/errorUtils";
 import { isWindows } from "@utils/platformUtils";
 
 import { chromeApplicationSupport } from "../ChromeApplicationSupport";
+import { readTextFile } from "../../runtime/FileSystemAdapter";
 
 /**
  * Windows Chrome Local State file structure for encrypted key
@@ -71,7 +71,7 @@ async function decryptDPAPIKey(encryptedKey: Buffer): Promise<Buffer> {
 export async function getChromePassword(): Promise<string> {
   try {
     const localStatePath = join(chromeApplicationSupport, "Local State");
-    const localStateContent = readFileSync(localStatePath, "utf8");
+    const localStateContent = readTextFile(localStatePath);
     const localState = JSON.parse(localStateContent) as WindowsChromeLocalState;
 
     if (!localState.os_crypt.encrypted_key) {

--- a/src/core/browsers/chromium/ChromiumCookieQueryStrategy.ts
+++ b/src/core/browsers/chromium/ChromiumCookieQueryStrategy.ts
@@ -1,4 +1,3 @@
-import { existsSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 
 import fg from "fast-glob";
@@ -7,6 +6,7 @@ import {
   type ChromiumBrowser,
   getChromiumBrowserPath,
 } from "../chrome/ChromiumBrowsers";
+import { fileExists, readTextFile } from "../runtime/FileSystemAdapter";
 
 import { BaseChromiumCookieQueryStrategy } from "./BaseChromiumCookieQueryStrategy";
 
@@ -112,11 +112,11 @@ export class ChromiumCookieQueryStrategy extends BaseChromiumCookieQueryStrategy
       const dataDir = dirname(dirname(firstPath));
       const localStatePath = join(dataDir, "Local State");
 
-      if (!existsSync(localStatePath)) {
+      if (!fileExists(localStatePath)) {
         return paths;
       }
 
-      const localState = JSON.parse(readFileSync(localStatePath, "utf8"));
+      const localState = JSON.parse(readTextFile(localStatePath));
       const profileCache = localState.profile?.info_cache || {};
 
       // Find the directory for the given profile name

--- a/src/core/browsers/firefox/FirefoxCookieQueryStrategy.ts
+++ b/src/core/browsers/firefox/FirefoxCookieQueryStrategy.ts
@@ -1,4 +1,3 @@
-import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { basename, join } from "node:path";
 
@@ -11,6 +10,7 @@ import { isFirefoxRunning } from "@utils/processDetector";
 
 import type { ExportedCookie } from "../../../types/schemas";
 import { BaseCookieQueryStrategy } from "../BaseCookieQueryStrategy";
+import { fileExists, readTextFile } from "../runtime/FileSystemAdapter";
 import { FIREFOX_DATA_DIRS } from "../BrowserAvailability";
 import { BrowserLockHandler } from "../BrowserLockHandler";
 import { getGlobalConnectionManager } from "../sql/DatabaseConnectionManager";
@@ -77,7 +77,7 @@ function findFirefoxCookieFiles(
         "Mozilla",
         "Firefox Developer Edition",
       );
-      if (existsSync(devEditionPath)) {
+      if (fileExists(devEditionPath)) {
         profileDirs.push(devEditionPath);
         patterns.push(join(devEditionPath, "Profiles", "*", "cookies.sqlite"));
       }
@@ -89,7 +89,7 @@ function findFirefoxCookieFiles(
         "Mozilla",
         "Firefox ESR",
       );
-      if (existsSync(esrPath)) {
+      if (fileExists(esrPath)) {
         profileDirs.push(esrPath);
         patterns.push(join(esrPath, "Profiles", "*", "cookies.sqlite"));
       }
@@ -101,7 +101,7 @@ function findFirefoxCookieFiles(
         "Mozilla",
         "Firefox",
       );
-      if (existsSync(localFirefoxPath)) {
+      if (fileExists(localFirefoxPath)) {
         profileDirs.push(localFirefoxPath);
         patterns.push(
           join(localFirefoxPath, "Profiles", "*", "cookies.sqlite"),
@@ -127,7 +127,7 @@ function findFirefoxCookieFiles(
       return [];
   }
 
-  const existingProfileDirs = profileDirs.filter((dir) => existsSync(dir));
+  const existingProfileDirs = profileDirs.filter((dir) => fileExists(dir));
 
   if (existingProfileDirs.length === 0) {
     logger.debug(
@@ -180,7 +180,7 @@ export function parseFirefoxProfilesIni(
   iniPath: string,
 ): FirefoxProfileEntry[] {
   try {
-    const content = readFileSync(iniPath, "utf8");
+    const content = readTextFile(iniPath);
     const lines = content.split(/\r?\n/);
     const profiles: FirefoxProfileEntry[] = [];
 
@@ -259,7 +259,7 @@ function filterByFirefoxProfile(
 
   for (const dataDir of profileDirs) {
     const iniPath = join(dataDir, "profiles.ini");
-    if (!existsSync(iniPath)) {
+    if (!fileExists(iniPath)) {
       continue;
     }
 
@@ -281,7 +281,7 @@ function filterByFirefoxProfile(
     const knownNames = new Set<string>();
     for (const dataDir of profileDirs) {
       const iniPath = join(dataDir, "profiles.ini");
-      if (!existsSync(iniPath)) {
+      if (!fileExists(iniPath)) {
         continue;
       }
       for (const p of parseFirefoxProfilesIni(iniPath)) {

--- a/src/core/browsers/runtime/FileSystemAdapter.ts
+++ b/src/core/browsers/runtime/FileSystemAdapter.ts
@@ -13,7 +13,8 @@
  */
 
 /**
- * Minimal synchronous filesystem surface required by browser detection.
+ * Minimal synchronous filesystem surface required by browser detection and the
+ * browser-specific cookie query strategies.
  */
 export interface FileSystemAdapter {
   /**
@@ -27,13 +28,36 @@ export interface FileSystemAdapter {
    * Read the leading bytes of a file without loading the whole file.
    *
    * Used to sniff format signatures (e.g. Safari's `cook` binary cookie magic
-   * bytes) cheaply, even when the underlying store is large.
+   * bytes) cheaply, even when the underlying store is large. This is a tolerant
+   * "sniff" operation — it returns `null` rather than throwing on failure.
    *
    * @param path - Path to the file to read
    * @param length - Number of bytes to read from the start of the file
    * @returns A buffer of up to `length` bytes, or `null` if the read failed
    */
   readLeadingBytes(path: string, length: number): Buffer | null;
+
+  /**
+   * Read an entire file as a raw `Buffer`.
+   *
+   * Unlike {@link readLeadingBytes}, this is a "load" operation and throws on
+   * failure, matching `fs.readFileSync` semantics so existing call sites keep
+   * their error behaviour.
+   *
+   * @param path - Path to the file to read
+   * @returns The full file contents as a `Buffer`
+   */
+  readFile(path: string): Buffer;
+
+  /**
+   * Read an entire file as a UTF-8 string.
+   *
+   * Throws on failure, matching `fs.readFileSync(path, "utf8")` semantics.
+   *
+   * @param path - Path to the file to read
+   * @returns The full file contents decoded as UTF-8
+   */
+  readTextFile(path: string): string;
 }
 
 /**
@@ -80,4 +104,38 @@ export function getFileSystemAdapter(): FileSystemAdapter {
   const adapter = createNodeFileSystemAdapter();
   currentAdapter = adapter;
   return adapter;
+}
+
+/**
+ * Convenience wrapper for {@link FileSystemAdapter.fileExists} on the active
+ * adapter. Lets call sites read like `fileExists(path)` instead of threading
+ * `getFileSystemAdapter()` through every check.
+ *
+ * @param path - Path to test
+ * @returns True when the path exists
+ */
+export function fileExists(path: string): boolean {
+  return getFileSystemAdapter().fileExists(path);
+}
+
+/**
+ * Convenience wrapper for {@link FileSystemAdapter.readFile} on the active
+ * adapter.
+ *
+ * @param path - Path to read
+ * @returns The full file contents as a `Buffer`
+ */
+export function readFile(path: string): Buffer {
+  return getFileSystemAdapter().readFile(path);
+}
+
+/**
+ * Convenience wrapper for {@link FileSystemAdapter.readTextFile} on the active
+ * adapter.
+ *
+ * @param path - Path to read
+ * @returns The full file contents decoded as UTF-8
+ */
+export function readTextFile(path: string): string {
+  return getFileSystemAdapter().readTextFile(path);
 }

--- a/src/core/browsers/runtime/NodeFileSystemAdapter.ts
+++ b/src/core/browsers/runtime/NodeFileSystemAdapter.ts
@@ -7,7 +7,13 @@
  * this adapter is a correct synchronous implementation under Bun as well.
  */
 
-import { closeSync, existsSync, openSync, readSync } from "node:fs";
+import {
+  closeSync,
+  existsSync,
+  openSync,
+  readFileSync,
+  readSync,
+} from "node:fs";
 
 import { createTaggedLogger } from "@utils/logHelpers";
 
@@ -23,6 +29,14 @@ export function createNodeFileSystemAdapter(): FileSystemAdapter {
   return {
     fileExists(path: string): boolean {
       return existsSync(path);
+    },
+
+    readFile(path: string): Buffer {
+      return readFileSync(path);
+    },
+
+    readTextFile(path: string): string {
+      return readFileSync(path, "utf8");
     },
 
     readLeadingBytes(path: string, length: number): Buffer | null {

--- a/src/core/browsers/runtime/__tests__/FileSystemAdapter.test.ts
+++ b/src/core/browsers/runtime/__tests__/FileSystemAdapter.test.ts
@@ -63,6 +63,8 @@ describe("FileSystemAdapter", () => {
       const injected: FileSystemAdapter = {
         fileExists: () => false,
         readLeadingBytes: () => null,
+        readFile: () => Buffer.alloc(0),
+        readTextFile: () => "",
       };
       setFileSystemAdapter(injected);
       expect(getFileSystemAdapter()).toBe(injected);
@@ -72,6 +74,8 @@ describe("FileSystemAdapter", () => {
       const injected: FileSystemAdapter = {
         fileExists: () => false,
         readLeadingBytes: () => null,
+        readFile: () => Buffer.alloc(0),
+        readTextFile: () => "",
       };
       setFileSystemAdapter(injected);
       expect(getFileSystemAdapter()).toBe(injected);
@@ -107,6 +111,21 @@ describe("FileSystemAdapter", () => {
 
     it("returns null when the file does not exist", () => {
       expect(adapter.readLeadingBytes(join(tmpDir, "missing"), 4)).toBeNull();
+    });
+
+    it("reads an entire file as a Buffer", () => {
+      const buf = adapter.readFile(cookFile);
+      expect(Buffer.isBuffer(buf)).toBe(true);
+      expect(buf.toString("ascii")).toBe("cookEXTRA");
+    });
+
+    it("reads an entire file as UTF-8 text", () => {
+      expect(adapter.readTextFile(cookFile)).toBe("cookEXTRA");
+    });
+
+    it("throws when reading a missing file (load semantics)", () => {
+      expect(() => adapter.readFile(join(tmpDir, "missing"))).toThrow();
+      expect(() => adapter.readTextFile(join(tmpDir, "missing"))).toThrow();
     });
   });
 });

--- a/src/core/browsers/safari/BinaryCodableCookies.ts
+++ b/src/core/browsers/safari/BinaryCodableCookies.ts
@@ -1,5 +1,4 @@
 import { Buffer } from "node:buffer";
-import { readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
@@ -7,6 +6,7 @@ import type { BinaryCookieRow } from "../../../types/schemas";
 import { getErrorMessage } from "../../../utils/errorUtils";
 import { createTaggedLogger, logWarn } from "../../../utils/logHelpers";
 
+import { readFile } from "../runtime/FileSystemAdapter";
 import { BinaryCodablePage } from "./BinaryCodablePage";
 import type { BinaryCodableContainer } from "./interfaces/BinaryCodableContainer";
 
@@ -48,7 +48,7 @@ export class BinaryCodableCookies {
    * @returns A new BinaryCookies instance
    */
   public static fromFile(path: string): BinaryCodableCookies {
-    const buffer = readFileSync(path);
+    const buffer = readFile(path);
     return new BinaryCodableCookies(buffer);
   }
 

--- a/src/core/browsers/sql/EnhancedCookieQueryService.ts
+++ b/src/core/browsers/sql/EnhancedCookieQueryService.ts
@@ -3,7 +3,6 @@
  * Combines query building, connection management, and validation in a unified interface
  */
 
-import { existsSync } from "node:fs";
 import { join } from "node:path";
 
 import fg from "fast-glob";
@@ -11,6 +10,7 @@ import type { SqliteDatabase } from "./adapters/DatabaseAdapter";
 import { createTaggedLogger, logError } from "@utils/logHelpers";
 import { getPlatform } from "@utils/platformUtils";
 import { CHROMIUM_DATA_DIRS, FIREFOX_DATA_DIRS } from "../BrowserAvailability";
+import { fileExists } from "../runtime/FileSystemAdapter";
 
 import type { ExportedCookie } from "../../../types/schemas";
 import { chromeTimestampToDate } from "../../../utils/chromeDates";
@@ -453,7 +453,7 @@ export class EnhancedCookieQueryService {
     const platform = getPlatform();
     const dataDir = CHROMIUM_DATA_DIRS[platform]?.[browser];
 
-    if (!dataDir || !existsSync(dataDir)) {
+    if (!dataDir || !fileExists(dataDir)) {
       logger.debug("No data directory found", { browser, platform });
       return [];
     }
@@ -486,7 +486,7 @@ export class EnhancedCookieQueryService {
     const needsProfilesSubdir = platform === "darwin" || platform === "win32";
     const profilesDirs = baseDirs
       .map((dir) => (needsProfilesSubdir ? join(dir, "Profiles") : dir))
-      .filter((dir) => existsSync(dir));
+      .filter((dir) => fileExists(dir));
 
     if (profilesDirs.length === 0) {
       logger.debug("Firefox profiles directory not found", {


### PR DESCRIPTION
## Summary

Follow-up to #548. After that PR routed *detection* fs access through the runtime layer, the browser **strategies**, CLI, Safari binary reader, and availability/discovery helpers still imported `node:fs` directly. This completes the consistency pass identified in the #548 audit.

## Changes

- **Extend `FileSystemAdapter`** with two load operations:
  - `readFile(path): Buffer` and `readTextFile(path): string` — both **throw on failure** (matching `fs.readFileSync` semantics), distinct from the tolerant `readLeadingBytes` which returns `null`.
  - Module-level `fileExists` / `readFile` / `readTextFile` convenience wrappers so call sites read like the originals.
- **Route 7 modules** through the adapter — none imports `node:fs` anymore:
  `cli.ts`, `BrowserAvailability`, `getChromePassword` (Windows DPAPI), `ChromiumCookieQueryStrategy`, `FirefoxCookieQueryStrategy`, `BinaryCodableCookies` (Safari), `EnhancedCookieQueryService`.

Synchronous disk access is now concentrated behind the runtime layer that `src/node.ts` / `src/bun.ts` wire via `setFileSystemAdapter`.

## Why

Per the runtime-layer principle: browser logic shouldn't bind `node:fs` directly. Consolidating fs access behind one injectable seam means runtime differences (Node vs Bun) and any future async path live in one place.

## Verification

Behaviour-neutral refactor:
- `pnpm type-check` ✅ · `pnpm lint` (228 files) ✅
- `pnpm test` — **644 passing**, 4 skipped, 78 suites ✅
- `pnpm build` remains **warning-free**; lib bundles now consolidate fs imports through `NodeFileSystemAdapter` (fully used, no orphan).
- **17** `FileSystemAdapter` tests incl. new `readFile`/`readTextFile` coverage on both Node and Bun adapters.