### PR TITLE
chore(lint): ban direct node:fs imports in browser/cli modules

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -113,6 +113,32 @@
           }
         }
       }
+    },
+    {
+      "includes": [
+        "src/core/browsers/**/*.ts",
+        "src/cli/**/*.ts",
+        "!src/core/browsers/runtime/**",
+        "!**/__tests__/**",
+        "!**/__mocks__/**",
+        "!**/*.test.ts",
+        "!**/*.spec.ts"
+      ],
+      "linter": {
+        "rules": {
+          "style": {
+            "noRestrictedImports": {
+              "level": "error",
+              "options": {
+                "paths": {
+                  "node:fs": "Import disk access through the runtime FileSystemAdapter (src/core/browsers/runtime/FileSystemAdapter) instead of node:fs directly.",
+                  "fs": "Import disk access through the runtime FileSystemAdapter (src/core/browsers/runtime/FileSystemAdapter) instead of node:fs directly."
+                }
+              }
+            }
+          }
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary

Guardrail follow-up to #548 + #549. Now that all browser/CLI disk access routes through the runtime `FileSystemAdapter`, this adds a Biome `noRestrictedImports` override that **forbids `node:fs`/`fs` imports** in `src/core/browsers/**` and `src/cli/**` — so the routing can't silently regress.

## Scope (via Biome `overrides` with negated globs)

Banned in: `src/core/browsers/**`, `src/cli/**`.
Excluded (legitimately use `node:fs`): `src/core/browsers/runtime/**` (the adapter impls), `__tests__/`, `__mocks__/`, `*.test.ts`, `*.spec.ts`.

The rule's custom message points contributors to the adapter.

## Verification

- ✅ `pnpm lint` passes clean on all **228 files** with the rule active — independently re-confirms no stray `node:fs` imports remain.
- ✅ A deliberate `node:fs` import in a strategy is **flagged** with the guidance message ("Found 2 errors"), then reverted.

One-file config change; no runtime impact.