### PR TITLE
chore(lint): mirror node:fs import ban in ESLint config

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -252,4 +252,37 @@ export default [
       "max-lines-per-function": ["error", { max: 100 }],
     },
   },
+  {
+    // Mirror the Biome `noRestrictedImports` guardrail: production browser and
+    // CLI modules must reach disk through the runtime FileSystemAdapter, never
+    // `node:fs` directly. The runtime layer and tests are exempt (they own the
+    // real fs access and the fixtures, respectively).
+    files: ["src/core/browsers/**/*.ts", "src/cli/**/*.ts"],
+    ignores: [
+      "src/core/browsers/runtime/**",
+      "**/__tests__/**",
+      "**/__mocks__/**",
+      "**/*.test.ts",
+      "**/*.spec.ts",
+    ],
+    rules: {
+      "@typescript-eslint/no-restricted-imports": [
+        "error",
+        {
+          paths: [
+            {
+              name: "node:fs",
+              message:
+                "Import disk access through the runtime FileSystemAdapter (src/core/browsers/runtime/FileSystemAdapter) instead of node:fs directly.",
+            },
+            {
+              name: "fs",
+              message:
+                "Import disk access through the runtime FileSystemAdapter (src/core/browsers/runtime/FileSystemAdapter) instead of node:fs directly.",
+            },
+          ],
+        },
+      ],
+    },
+  },
 ];


### PR DESCRIPTION
## Summary

Mirrors the Biome `noRestrictedImports` guardrail (PR #550) into the ESLint config so a direct `node:fs`/`fs` import in a production browser/CLI module is caught regardless of which linter runs.

## Why

PR #550 added the ban to Biome (`pnpm lint`, the enforced gate). ESLint (`pnpm lint:eslint`) is a secondary linter with no equivalent rule, leaving a coverage gap. This closes it for defence-in-depth.

## Scope & exemptions

Scoped to `src/core/browsers/**` + `src/cli/**`, exempting `runtime/**` (which legitimately owns the `node:fs` access) and test/mock files — identical boundaries to the Biome rule. Uses `@typescript-eslint/no-restricted-imports` so type-only imports are also flagged, matching Biome's blanket ban.

## Verification

- Injected a deliberate `import { existsSync } from "node:fs"` into `FirefoxCookieQueryStrategy.ts` → ESLint flagged it with the custom adapter-redirect message, then reverted.
- `pnpm lint` (Biome) clean on 228 files.
- Pre-commit + pre-push hooks green.

Relates to the FileSystemAdapter runtime-boundary work in #548 / #549 / #550.