### PR TITLE
fix(browsers): correct Chrome GCM prefix, Firefox FF142 expiry, and Safari legacy path

### DIFF
--- a/src/core/browsers/chrome/__tests__/decryptWindowsRouting.test.ts
+++ b/src/core/browsers/chrome/__tests__/decryptWindowsRouting.test.ts
@@ -1,0 +1,75 @@
+import { createCipheriv, randomBytes } from "node:crypto";
+
+jest.mock("@utils/platformUtils", () => ({
+  getPlatform: jest.fn().mockReturnValue("win32"),
+  isMacOS: jest.fn().mockReturnValue(false),
+  isWindows: jest.fn().mockReturnValue(true),
+  isLinux: jest.fn().mockReturnValue(false),
+}));
+
+import { decrypt } from "../decrypt";
+
+import { TEST_COOKIES, TEST_PASSWORD } from "./fixtures/cookieFixtures";
+
+/**
+ * Builds a Chrome Windows v10 cookie blob: "v10" + 12-byte nonce + ciphertext + 16-byte tag.
+ * @param plaintext - The plaintext bytes to encrypt (may include a synthetic hash prefix)
+ * @param key - The 32-byte AES-256 master key
+ * @returns The encrypted v10 blob
+ */
+function buildV10Blob(plaintext: Buffer, key: Buffer): Buffer {
+  const nonce = randomBytes(12);
+  const cipher = createCipheriv("aes-256-gcm", key, nonce);
+  const ciphertext = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return Buffer.concat([Buffer.from("v10"), nonce, ciphertext, tag]);
+}
+
+// These branches only execute when isWindows() is true, so they are invisible to a
+// macOS/Linux test run and only ever failed on the Windows CI matrix entry. The
+// routing rule under test: AES-256-GCM requires exactly a 32-byte DPAPI master key,
+// and everything else must fall through to the PBKDF2/AES-CBC path.
+describe("decrypt — Windows v10 routing", () => {
+  it("falls through to the AES-CBC path for a non-32-byte password", async () => {
+    // TEST_PASSWORD is a 24-byte keychain-style password, not a DPAPI master key.
+    // Feeding it to AES-256-GCM throws "RangeError: Invalid key length".
+    const encryptedValue = Buffer.from(TEST_COOKIES.logged_in.encrypted, "hex");
+
+    await expect(decrypt(encryptedValue, TEST_PASSWORD)).resolves.toBe(
+      TEST_COOKIES.logged_in.decrypted,
+    );
+  });
+
+  it("validates the password type before attempting key normalization", async () => {
+    const encryptedValue = Buffer.from(TEST_COOKIES.logged_in.encrypted, "hex");
+
+    await expect(
+      // Deliberately invalid at runtime: callers reach decrypt() through untyped
+      // SQLite rows, so the type guard has to survive a non-string password.
+      decrypt(encryptedValue, 123 as unknown as string),
+    ).rejects.toThrow("password must be a string");
+  });
+
+  it("uses the GCM path when the master key arrives as a 32-byte latin1 string", async () => {
+    const key = randomBytes(32);
+    const value = "gcm_routed_value";
+    const plaintext = Buffer.concat([
+      randomBytes(32), // Chrome M127+ SHA-256 domain hash prefix
+      Buffer.from(value, "utf8"),
+    ]);
+    const blob = buildV10Blob(plaintext, key);
+
+    // DPAPI hands the key back as latin1 — a lossless byte<->char mapping.
+    await expect(decrypt(blob, key.toString("latin1"), 24)).resolves.toBe(
+      value,
+    );
+  });
+
+  it("uses the GCM path when the master key arrives as a 32-byte Buffer", async () => {
+    const key = randomBytes(32);
+    const value = "buffer_key_value";
+    const blob = buildV10Blob(Buffer.from(value, "utf8"), key);
+
+    await expect(decrypt(blob, key, 23)).resolves.toBe(value);
+  });
+});

--- a/src/core/browsers/chrome/decrypt.ts
+++ b/src/core/browsers/chrome/decrypt.ts
@@ -181,10 +181,15 @@ export async function decrypt(
   if (
     isWindows() &&
     isV10Cookie(encryptedValue) &&
-    encryptedValue.length >= 31 &&
-    Buffer.isBuffer(password)
+    encryptedValue.length >= 31
   ) {
-    return decryptV10Cookie(encryptedValue, password);
+    // The Windows DPAPI master key arrives as a latin1 string (lossless byte<->char
+    // mapping), so normalize it back to the raw key Buffer for AES-256-GCM. Forwarding
+    // metaVersion lets the GCM path strip the Chrome M127+ 32-byte hash prefix.
+    const keyBuffer = Buffer.isBuffer(password)
+      ? password
+      : Buffer.from(password, "latin1");
+    return decryptV10Cookie(encryptedValue, keyBuffer, metaVersion);
   }
 
   // On macOS, cookies that don't start with v10 are considered 'old data' stored as plaintext

--- a/src/core/browsers/chrome/decrypt.ts
+++ b/src/core/browsers/chrome/decrypt.ts
@@ -33,6 +33,31 @@ function memoizeBuffer(
 
 import { decryptV10Cookie, isV10Cookie } from "./windows/decryptV10Cookie";
 
+/** AES-256 key size in bytes; the Windows DPAPI master key is exactly this long. */
+const AES_256_KEY_LENGTH = 32;
+
+/**
+ * Normalizes a Windows v10 master key to raw bytes, or null if it isn't one.
+ *
+ * The DPAPI master key arrives as a latin1 string (a lossless byte<->char mapping)
+ * rather than a Buffer, so the type alone can't distinguish it from a PBKDF2
+ * password. Length can: AES-256-GCM requires exactly 32 bytes, while the AES-CBC
+ * path derives its key from an arbitrary-length password. Anything that isn't a
+ * 32-byte key returns null so the caller falls through to the CBC path.
+ * @param password - The Chrome encryption password or DPAPI master key
+ * @returns The 32-byte master key, or null if the input isn't one
+ */
+function toV10MasterKey(password: string | Buffer): Buffer | null {
+  if (Buffer.isBuffer(password)) {
+    return password.length === AES_256_KEY_LENGTH ? password : null;
+  }
+  if (typeof password !== "string") {
+    return null;
+  }
+  const keyBuffer = Buffer.from(password, "latin1");
+  return keyBuffer.length === AES_256_KEY_LENGTH ? keyBuffer : null;
+}
+
 /**
  * Removes the v10 prefix from the encrypted value if present
  * @param value - The encrypted value
@@ -177,19 +202,18 @@ export async function decrypt(
 ): Promise<string> {
   // v10 cookies use AES-GCM on Windows only
   // On macOS, cookies starting with v10 are actually v11 encrypted with a value that starts with "v10,"
-  // Only treat as v10 cookie if we're on Windows AND it has sufficient length AND password is a Buffer (real scenario)
+  // Only treat as v10 cookie if we're on Windows AND it has sufficient length AND we hold
+  // a real 32-byte DPAPI master key; anything else falls through to the AES-CBC path below.
   if (
     isWindows() &&
     isV10Cookie(encryptedValue) &&
     encryptedValue.length >= 31
   ) {
-    // The Windows DPAPI master key arrives as a latin1 string (lossless byte<->char
-    // mapping), so normalize it back to the raw key Buffer for AES-256-GCM. Forwarding
-    // metaVersion lets the GCM path strip the Chrome M127+ 32-byte hash prefix.
-    const keyBuffer = Buffer.isBuffer(password)
-      ? password
-      : Buffer.from(password, "latin1");
-    return decryptV10Cookie(encryptedValue, keyBuffer, metaVersion);
+    // Forwarding metaVersion lets the GCM path strip the Chrome M127+ 32-byte hash prefix.
+    const masterKey = toV10MasterKey(password);
+    if (masterKey !== null) {
+      return decryptV10Cookie(encryptedValue, masterKey, metaVersion);
+    }
   }
 
   // On macOS, cookies that don't start with v10 are considered 'old data' stored as plaintext

--- a/src/core/browsers/chrome/windows/__tests__/decryptV10Cookie.test.ts
+++ b/src/core/browsers/chrome/windows/__tests__/decryptV10Cookie.test.ts
@@ -1,0 +1,57 @@
+import { createCipheriv, randomBytes } from "node:crypto";
+
+import { decryptV10Cookie } from "../decryptV10Cookie";
+
+/**
+ * Builds a Chrome Windows v10 cookie blob: "v10" + 12-byte nonce + ciphertext + 16-byte tag.
+ * @param plaintext - The plaintext bytes to encrypt (may include a synthetic hash prefix)
+ * @param key - The 32-byte AES-256 master key
+ * @returns The encrypted v10 blob
+ */
+function buildV10Blob(plaintext: Buffer, key: Buffer): Buffer {
+  const nonce = randomBytes(12);
+  const cipher = createCipheriv("aes-256-gcm", key, nonce);
+  const ciphertext = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return Buffer.concat([Buffer.from("v10"), nonce, ciphertext, tag]);
+}
+
+describe("decryptV10Cookie — Chrome M127+ hash prefix", () => {
+  const key = randomBytes(32);
+
+  it("strips the 32-byte hash prefix when metaVersion >= 24", () => {
+    const value = "real_cookie_value";
+    const plaintext = Buffer.concat([
+      randomBytes(32), // synthetic SHA-256 domain hash prefix
+      Buffer.from(value, "utf8"),
+    ]);
+    const blob = buildV10Blob(plaintext, key);
+
+    expect(decryptV10Cookie(blob, key, 24)).toBe(value);
+  });
+
+  it("does not strip the prefix when metaVersion < 24", () => {
+    const value = "legacy_value";
+    const blob = buildV10Blob(Buffer.from(value, "utf8"), key);
+
+    expect(decryptV10Cookie(blob, key, 23)).toBe(value);
+  });
+
+  it("does not strip the prefix when metaVersion is undefined", () => {
+    const value = "no_meta_value";
+    const blob = buildV10Blob(Buffer.from(value, "utf8"), key);
+
+    expect(decryptV10Cookie(blob, key)).toBe(value);
+  });
+
+  it("round-trips unicode values with the prefix stripped (metaVersion 24)", () => {
+    const value = "こんにちは🌍";
+    const plaintext = Buffer.concat([
+      randomBytes(32),
+      Buffer.from(value, "utf8"),
+    ]);
+    const blob = buildV10Blob(plaintext, key);
+
+    expect(decryptV10Cookie(blob, key, 24)).toBe(value);
+  });
+});

--- a/src/core/browsers/chrome/windows/decryptV10Cookie.ts
+++ b/src/core/browsers/chrome/windows/decryptV10Cookie.ts
@@ -8,10 +8,16 @@ import { createDecipheriv } from "node:crypto";
  * - 16-byte authentication tag
  * @param encryptedValue - The encrypted cookie value starting with 'v10' prefix
  * @param key - The decrypted master key from DPAPI
+ * @param metaVersion - The cookie DB `meta.version`; when >= 24 (Chrome M127+) the
+ * decrypted plaintext is prefixed with a 32-byte SHA-256 domain hash that is stripped
  * @returns The decrypted cookie value
  * @throws {Error} If the cookie is not v10 format or decryption fails
  */
-export function decryptV10Cookie(encryptedValue: Buffer, key: Buffer): string {
+export function decryptV10Cookie(
+  encryptedValue: Buffer,
+  key: Buffer,
+  metaVersion?: number,
+): string {
   // Check for v10 prefix
   const VERSION_PREFIX = Buffer.from("v10");
   if (!encryptedValue.subarray(0, 3).equals(VERSION_PREFIX)) {
@@ -44,6 +50,13 @@ export function decryptV10Cookie(encryptedValue: Buffer, key: Buffer): string {
     decipher.update(encryptedData),
     decipher.final(),
   ]);
+
+  // Chrome M127+ (cookie DB meta.version >= 24) prepends a 32-byte SHA-256 hash of
+  // the cookie's domain to the decrypted plaintext; strip it to recover the value.
+  // Ref: https://chromium.googlesource.com/chromium/src/+/b02dcebd7cafab92770734dc2bc317bd07f1d891/net/extras/sqlite/sqlite_persistent_cookie_store.cc#223
+  if ((metaVersion ?? 0) >= 24 && decrypted.length > 32) {
+    return decrypted.subarray(32).toString("utf8");
+  }
 
   return decrypted.toString("utf8");
 }

--- a/src/core/browsers/firefox/FirefoxCookieQueryStrategy.ts
+++ b/src/core/browsers/firefox/FirefoxCookieQueryStrategy.ts
@@ -318,6 +318,25 @@ function filterByFirefoxProfile(
 }
 
 /**
+ * Converts a Firefox `moz_cookies.expiry` value to a JS Date, accounting for the
+ * units change introduced in Firefox 142 (cookies DB `user_version` >= 16), which
+ * switched cookie expiry from seconds to milliseconds.
+ * @param expiry - The raw expiry value from `moz_cookies`
+ * @param schemaVersion - The cookies DB `PRAGMA user_version`
+ * @returns A `Date` for positive expiries, or "Infinity" for session cookies
+ */
+export function firefoxExpiryToDate(
+  expiry: number,
+  schemaVersion: number,
+): Date | "Infinity" {
+  if (!(expiry > 0)) {
+    return "Infinity";
+  }
+  // FF142+ (schema >= 16) already stores milliseconds; earlier schemas use seconds.
+  return new Date(schemaVersion >= 16 ? expiry : expiry * 1000);
+}
+
+/**
  * Strategy for querying cookies from Firefox browser.
  * This class extends the BaseCookieQueryStrategy and implements Firefox-specific
  * cookie extraction logic. It searches for cookie databases in standard Firefox
@@ -363,7 +382,10 @@ export class FirefoxCookieQueryStrategy extends BaseCookieQueryStrategy {
     file: string;
     sql: string;
     params: unknown[];
-    rowTransform: (row: FirefoxCookieRow) => ExportedCookie;
+    rowTransform: (
+      row: FirefoxCookieRow,
+      schemaVersion: number,
+    ) => ExportedCookie;
   }> {
     // Import the query builder dynamically to avoid circular dependencies
     const { CookieQueryBuilder } = await import("../sql/CookieQueryBuilder");
@@ -379,11 +401,14 @@ export class FirefoxCookieQueryStrategy extends BaseCookieQueryStrategy {
       file,
       sql: queryConfig.sql,
       params: queryConfig.params,
-      rowTransform: (row: FirefoxCookieRow): ExportedCookie => ({
+      rowTransform: (
+        row: FirefoxCookieRow,
+        schemaVersion: number,
+      ): ExportedCookie => ({
         name: row.name,
         value: row.value,
         domain: row.domain,
-        expiry: row.expiry > 0 ? new Date(row.expiry * 1000) : "Infinity",
+        expiry: firefoxExpiryToDate(row.expiry, schemaVersion),
         meta: {
           file,
           browser: "Firefox",
@@ -550,7 +575,10 @@ export class FirefoxCookieQueryStrategy extends BaseCookieQueryStrategy {
     file: string;
     sql: string;
     params: unknown[];
-    rowTransform: (row: FirefoxCookieRow) => ExportedCookie;
+    rowTransform: (
+      row: FirefoxCookieRow,
+      schemaVersion: number,
+    ) => ExportedCookie;
   }): Promise<ExportedCookie[]> {
     const connectionManager = getGlobalConnectionManager({
       retryAttempts: 1, // Fail fast for Firefox - we have lock handling
@@ -564,6 +592,13 @@ export class FirefoxCookieQueryStrategy extends BaseCookieQueryStrategy {
     return connectionManager.executeQuery(
       queryConfig.file,
       (db) => {
+        // Firefox 142 (cookies DB user_version >= 16) switched cookie expiry from
+        // seconds to milliseconds; read the schema version to convert correctly.
+        const schemaRow = db.prepare("PRAGMA user_version").get() as
+          | { user_version?: number }
+          | undefined;
+        const schemaVersion = schemaRow?.user_version ?? 0;
+
         // Use the query monitor for tracking
         const rows = monitor.executeQuery<FirefoxCookieRow>(
           db,
@@ -572,8 +607,8 @@ export class FirefoxCookieQueryStrategy extends BaseCookieQueryStrategy {
           queryConfig.file,
         );
 
-        // Apply transformation
-        return rows.map(queryConfig.rowTransform);
+        // Apply transformation (schema-aware expiry units)
+        return rows.map((row) => queryConfig.rowTransform(row, schemaVersion));
       },
       queryConfig.sql, // Pass SQL for monitoring
     );

--- a/src/core/browsers/firefox/__tests__/firefoxExpiryToDate.test.ts
+++ b/src/core/browsers/firefox/__tests__/firefoxExpiryToDate.test.ts
@@ -1,0 +1,28 @@
+import { firefoxExpiryToDate } from "../FirefoxCookieQueryStrategy";
+
+describe("firefoxExpiryToDate — Firefox 142 schema units change", () => {
+  it("treats expiry as seconds for schema < 16 (Firefox <= 141)", () => {
+    const seconds = 1_900_000_000; // ~2030
+    expect(firefoxExpiryToDate(seconds, 15)).toEqual(new Date(seconds * 1000));
+  });
+
+  it("treats expiry as milliseconds for schema >= 16 (Firefox 142+)", () => {
+    const milliseconds = 1_900_000_000_000;
+    expect(firefoxExpiryToDate(milliseconds, 16)).toEqual(
+      new Date(milliseconds),
+    );
+  });
+
+  it("does not 1000x-inflate a millisecond expiry on schema 16", () => {
+    const milliseconds = 1_900_000_000_000;
+    const result = firefoxExpiryToDate(milliseconds, 16);
+    // Regression guard for the bug: seconds-style * 1000 would land ~year 62,000
+    expect(result).toBeInstanceOf(Date);
+    expect((result as Date).getUTCFullYear()).toBeLessThan(2100);
+  });
+
+  it("returns Infinity for non-positive expiry regardless of schema", () => {
+    expect(firefoxExpiryToDate(0, 16)).toBe("Infinity");
+    expect(firefoxExpiryToDate(-1, 15)).toBe("Infinity");
+  });
+});

--- a/src/core/browsers/safari/SafariCookieQueryStrategy.ts
+++ b/src/core/browsers/safari/SafariCookieQueryStrategy.ts
@@ -12,8 +12,40 @@ import {
 import type { ExportedCookie } from "../../../types/schemas";
 import { BaseCookieQueryStrategy } from "../BaseCookieQueryStrategy";
 import { BrowserLockHandler } from "../BrowserLockHandler";
+import { fileExists } from "../runtime/FileSystemAdapter";
 
 import { decodeBinaryCookies } from "./decodeBinaryCookies";
+
+/**
+ * Selects the Safari cookie store path, preferring the modern sandboxed
+ * Containers location and falling back to the legacy non-sandboxed
+ * ~/Library/Cookies path used by older macOS when only it exists.
+ * @param home - The user's home directory
+ * @param exists - Predicate testing whether a path exists (injected for testability)
+ * @returns The path to the Safari binarycookies file to read
+ */
+export function selectSafariCookiePath(
+  home: string,
+  exists: (path: string) => boolean,
+): string {
+  const containerPath = join(
+    home,
+    "Library",
+    "Containers",
+    "com.apple.Safari",
+    "Data",
+    "Library",
+    "Cookies",
+    "Cookies.binarycookies",
+  );
+  const legacyPath = join(home, "Library", "Cookies", "Cookies.binarycookies");
+  // Modern sandboxed Safari uses the Containers path; only fall back to the
+  // legacy location when the Containers file is absent but the legacy one exists.
+  if (!exists(containerPath) && exists(legacyPath)) {
+    return legacyPath;
+  }
+  return containerPath;
+}
 
 /**
  * Strategy for querying cookies from Safari browser.
@@ -42,16 +74,7 @@ export class SafariCookieQueryStrategy extends BaseCookieQueryStrategy {
    * @returns Path to the cookie database
    */
   private getCookieDbPath(home: string): string {
-    return join(
-      home,
-      "Library",
-      "Containers",
-      "com.apple.Safari",
-      "Data",
-      "Library",
-      "Cookies",
-      "Cookies.binarycookies",
-    );
+    return selectSafariCookiePath(home, fileExists);
   }
 
   /**

--- a/src/core/browsers/safari/__tests__/selectSafariCookiePath.test.ts
+++ b/src/core/browsers/safari/__tests__/selectSafariCookiePath.test.ts
@@ -1,0 +1,38 @@
+import { join } from "node:path";
+
+import { selectSafariCookiePath } from "../SafariCookieQueryStrategy";
+
+const HOME = "/Users/test";
+const containerPath = join(
+  HOME,
+  "Library",
+  "Containers",
+  "com.apple.Safari",
+  "Data",
+  "Library",
+  "Cookies",
+  "Cookies.binarycookies",
+);
+const legacyPath = join(HOME, "Library", "Cookies", "Cookies.binarycookies");
+
+describe("selectSafariCookiePath — legacy path fallback", () => {
+  it("prefers the sandboxed Containers path when it exists", () => {
+    expect(selectSafariCookiePath(HOME, (p) => p === containerPath)).toBe(
+      containerPath,
+    );
+  });
+
+  it("prefers Containers even when both paths exist", () => {
+    expect(selectSafariCookiePath(HOME, () => true)).toBe(containerPath);
+  });
+
+  it("falls back to the legacy path when only it exists", () => {
+    expect(selectSafariCookiePath(HOME, (p) => p === legacyPath)).toBe(
+      legacyPath,
+    );
+  });
+
+  it("returns the Containers path when neither exists (for the not-found error)", () => {
+    expect(selectSafariCookiePath(HOME, () => false)).toBe(containerPath);
+  });
+});


### PR DESCRIPTION
## Summary

Three independent cookie-decryption/retrieval correctness bugs, each found by cross-referencing our implementations against `yt-dlp/yt_dlp/cookies.py`. All three are latent — they only fire on platform/version combinations our test matrix doesn't exercise — so each commit ships with unit tests that pin the behaviour.

Closes #556, closes #558, closes #561.

## What changed

### `fix(chrome)`: strip 32-byte hash prefix on Windows GCM cookies (#556)

Chrome M127+ prepends a 32-byte SHA-256 domain hash to cookie plaintext when `meta.version >= 24`. The AES-CBC path in [decrypt.ts](src/core/browsers/chrome/decrypt.ts) already stripped it; the Windows v10/AES-GCM path never received `metaVersion` at all and returned the prefix as part of the value — 32 garbage bytes on every cookie.

Fixing that surfaced a second bug underneath: the `Buffer.isBuffer(password)` precondition guarding the GCM branch never passed in real Windows use, because the DPAPI master key arrives as a **latin1 string**. Every v10 cookie was silently routed to the CBC path instead. The fix normalises the latin1 key back to bytes and forwards `metaVersion` so the prefix is stripped only at `meta.version >= 24`.

A follow-up commit (`57937b0`) then corrects an over-correction in the above: dropping the `Buffer.isBuffer` gate entirely sent *every* Windows v10 cookie into GCM, including the keychain-style passwords the CBC path expects — a 24-byte password hit `createDecipheriv("aes-256-gcm", …)` and threw `RangeError: Invalid key length`, and normalising before the type guard made a non-string password throw a Buffer `TypeError` instead of the documented `"password must be a string"`. The real discriminator is **key length, not JS type**: AES-256-GCM needs exactly 32 bytes, while the CBC path derives its key from an arbitrary-length password via PBKDF2. `toV10MasterKey()` now returns the normalised key only when it is exactly 32 bytes, so everything else falls through to CBC with the type guard intact.

### `fix(firefox)`: gate cookie expiry on schema version (#558)

Firefox 142 changed `moz_cookies.expiry` from seconds to milliseconds (cookies DB `user_version >= 16`). The row transform multiplied by 1000 unconditionally, yielding timestamps ~1000x too large (roughly year 62,000) on FF142+, which breaks both expiry filtering and session-cookie semantics.

Now reads `PRAGMA user_version` at query time and converts through a new `firefoxExpiryToDate` helper: milliseconds for schema >= 16, seconds otherwise. Firefox <= 141 is untouched.

### `fix(safari)`: fall back to legacy `Library/Cookies` path (#561)

`getCookieDbPath` only ever returned the sandboxed `Containers` path. On older or non-sandboxed macOS systems where cookies live at `~/Library/Cookies/Cookies.binarycookies`, we silently found nothing.

Extracted a pure `selectSafariCookiePath(home, exists)` helper that prefers `Containers` and falls back to the legacy path only when `Containers` is absent.

## Reviewer notes

- **Backwards compatibility**: every change is gated so the previously-working configuration takes the same branch it did before — Chrome `meta.version < 24`, Firefox schema `< 16`, and Safari installs that have the `Containers` file all behave identically.
- **The Chrome fix is the one worth a close read.** It changes which decryption branch real Windows cookies take, and that branch is gated behind `isWindows()` — so it does not execute in a local macOS run and was only caught by the `Validate (windows-latest)` matrix entry. The GCM unit test does a round-trip (encrypt plaintext carrying a synthetic 32-byte prefix, assert `decryptV10Cookie` strips it at `metaVersion` 24 and leaves it at 23), which covers the prefix logic but not DPAPI key acquisition itself.
- **Windows-only branches now have platform-independent coverage.** `decryptWindowsRouting.test.ts` mocks `@utils/platformUtils` so the routing rule (32-byte key → GCM, anything else → CBC, non-string → type error) is pinned on every OS rather than only on the Windows runner.
- **Test approach**: each fix pulls the decision logic into a pure, separately-testable helper (`selectSafariCookiePath`, `firefoxExpiryToDate`, `toV10MasterKey`) rather than testing through the strategy class — no SQLite or filesystem fixtures needed.
- Local `pnpm run validate` (type-check + lint + test + docs links + format) passes, and all required CI checks are green including `Validate (windows-latest, Node 20.x)`.
