### PR TITLE
fix(chrome): validate password type before normalizing Windows v10 key

### DIFF
--- a/src/core/browsers/chrome/__tests__/decryptWindowsRouting.test.ts
+++ b/src/core/browsers/chrome/__tests__/decryptWindowsRouting.test.ts
@@ -1,0 +1,83 @@
+import { createCipheriv, randomBytes } from "node:crypto";
+
+jest.mock("@utils/platformUtils", () => ({
+  getPlatform: jest.fn().mockReturnValue("win32"),
+  isMacOS: jest.fn().mockReturnValue(false),
+  isWindows: jest.fn().mockReturnValue(true),
+  isLinux: jest.fn().mockReturnValue(false),
+}));
+
+import { decrypt } from "../decrypt";
+import {
+  CHROME_DOMAIN_HASH_LENGTH,
+  CHROME_M127_META_VERSION,
+  WINDOWS_GCM_KEY_LENGTH,
+} from "../windows/decryptV10Cookie";
+
+import { TEST_COOKIES, TEST_PASSWORD } from "./fixtures/cookieFixtures";
+
+/**
+ * Builds a Chrome Windows v10 cookie blob: "v10" + 12-byte nonce + ciphertext + 16-byte tag.
+ * @param plaintext - The plaintext bytes to encrypt (may include a synthetic hash prefix)
+ * @param key - The 32-byte AES-256 master key
+ * @returns The encrypted v10 blob
+ */
+function buildV10Blob(plaintext: Buffer, key: Buffer): Buffer {
+  const nonce = randomBytes(12);
+  const cipher = createCipheriv("aes-256-gcm", key, nonce);
+  const ciphertext = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return Buffer.concat([Buffer.from("v10"), nonce, ciphertext, tag]);
+}
+
+// These branches only execute when isWindows() is true, so a macOS or Linux run never
+// reaches them and they are covered solely by the Windows CI matrix entry. Mocking the
+// platform pins the routing rule on every OS instead: AES-256-GCM takes a 32-byte DPAPI
+// master key, and anything else falls through to the PBKDF2/AES-CBC path.
+describe("decrypt — Windows v10 routing", () => {
+  it("falls through to the AES-CBC path for a non-32-byte password", async () => {
+    // TEST_PASSWORD is a 24-byte keychain-style password, not a DPAPI master key.
+    // Feeding it to AES-256-GCM throws "RangeError: Invalid key length".
+    const encryptedValue = Buffer.from(TEST_COOKIES.logged_in.encrypted, "hex");
+
+    await expect(decrypt(encryptedValue, TEST_PASSWORD)).resolves.toBe(
+      TEST_COOKIES.logged_in.decrypted,
+    );
+  });
+
+  it("reports a non-string password rather than a Buffer TypeError", async () => {
+    // Normalizing before the type guard surfaces "The first argument must be of type
+    // string..." from Buffer.from() instead of the documented validation error.
+    const encryptedValue = Buffer.from(TEST_COOKIES.logged_in.encrypted, "hex");
+
+    await expect(
+      // Deliberately invalid at runtime: callers reach decrypt() via untyped SQLite rows.
+      decrypt(encryptedValue, 123 as unknown as string),
+    ).rejects.toThrow("password must be a string");
+  });
+
+  it("uses the GCM path when the master key arrives as a latin1 string", async () => {
+    const key = randomBytes(WINDOWS_GCM_KEY_LENGTH);
+    const value = "gcm_routed_value";
+    const plaintext = Buffer.concat([
+      randomBytes(CHROME_DOMAIN_HASH_LENGTH), // Chrome M127+ SHA-256 domain hash
+      Buffer.from(value, "utf8"),
+    ]);
+    const blob = buildV10Blob(plaintext, key);
+
+    // DPAPI hands the key back as latin1 — a lossless byte<->char mapping.
+    await expect(
+      decrypt(blob, key.toString("latin1"), CHROME_M127_META_VERSION),
+    ).resolves.toBe(value);
+  });
+
+  it("uses the GCM path when the master key arrives as a Buffer", async () => {
+    const key = randomBytes(WINDOWS_GCM_KEY_LENGTH);
+    const value = "buffer_key_value";
+    const blob = buildV10Blob(Buffer.from(value, "utf8"), key);
+
+    await expect(
+      decrypt(blob, key, CHROME_M127_META_VERSION - 1),
+    ).resolves.toBe(value);
+  });
+});

--- a/src/core/browsers/chrome/decrypt.ts
+++ b/src/core/browsers/chrome/decrypt.ts
@@ -168,6 +168,26 @@ function deriveKey(password: string): Promise<Buffer> {
 }
 
 /**
+ * Normalizes a Windows v10 master key to raw bytes without throwing.
+ *
+ * `Buffer.from()` raises a TypeError on anything that isn't a string or bytes, and
+ * callers reach decrypt() through untyped SQLite rows. Returning null instead lets
+ * the caller fall through to the "password must be a string" guard, which reports
+ * the real problem.
+ * @param password - The Chrome encryption password or DPAPI master key
+ * @returns The key as raw bytes, or null if the input isn't string-or-Buffer
+ */
+function normalizeV10MasterKey(password: string | Buffer): Buffer | null {
+  if (Buffer.isBuffer(password)) {
+    return password;
+  }
+  if (typeof password !== "string") {
+    return null;
+  }
+  return Buffer.from(password, "latin1");
+}
+
+/**
  * Decrypts Chrome's encrypted cookie values
  * @param encryptedValue - The encrypted cookie value as a Buffer
  * @param password - The Chrome encryption password
@@ -192,10 +212,8 @@ export async function decrypt(
     // The Windows DPAPI master key arrives as a latin1 string (lossless byte<->char
     // mapping), so normalize it back to the raw key Buffer for AES-256-GCM. Forwarding
     // metaVersion lets the GCM path strip the Chrome M127+ 32-byte hash prefix.
-    const keyBuffer = Buffer.isBuffer(password)
-      ? password
-      : Buffer.from(password, "latin1");
-    if (keyBuffer.length === WINDOWS_GCM_KEY_LENGTH) {
+    const keyBuffer = normalizeV10MasterKey(password);
+    if (keyBuffer?.length === WINDOWS_GCM_KEY_LENGTH) {
       return decryptV10Cookie(encryptedValue, keyBuffer, metaVersion);
     }
   }


### PR DESCRIPTION
## Summary

Follow-up to #566. The Windows v10 dispatch normalises the password to bytes *before* the `"password must be a string"` guard runs, so an invalid password surfaces as a `Buffer` internals error instead of the documented validation error.

```
TypeError: The first argument must be of type string or an instance of Buffer,
ArrayBuffer, or Array or an Array-like Object. Received type number (123)
```

`Buffer.from()` throws on anything that isn't a string or bytes, and callers reach `decrypt()` through untyped SQLite rows — so the guard that exists specifically to catch this never gets the chance to report it.

## Why it wasn't caught

`decrypt.test.ts` already covers this via the `"should reject if password is not a string"` case, and the v10 fixture it uses is a 51-byte `v10` blob that *does* enter the branch. But the branch sits behind `isWindows()`, so:

- a local macOS run never reaches it, and
- the `Validate` matrix only runs on pull requests — the merge commit for #566 ran `CI Status` alone, so no Windows job has executed against main since.

I hit it because a stale local branch re-ran the pre-#566 code through the Windows matrix entry.

## What changed

- **`normalizeV10MasterKey()`** returns `null` instead of throwing for a non-string, non-Buffer password, so the caller falls through to the existing type guard. Valid keys are untouched: Buffers and latin1 strings normalise exactly as before, and the 32-byte `WINDOWS_GCM_KEY_LENGTH` check is unchanged.
- **`decryptWindowsRouting.test.ts`** mocks `@utils/platformUtils` so the Windows-only routing rules are pinned on every OS rather than only on the Windows runner:
  - 32-byte key (Buffer or latin1 string) → AES-256-GCM
  - other lengths → PBKDF2/AES-CBC fallback
  - non-string → `"password must be a string"`

## Verification

The new test was checked against **both** versions of `decrypt.ts` — it fails on main with the `TypeError` above and passes with this change, so it genuinely pins the fix rather than just documenting current behaviour. Full `pnpm run validate` passes locally (82 suites, 669 tests).

The `RangeError: Invalid key length` failure from the same Windows run is **not** present on main — #566's review-gap commit already added the `WINDOWS_GCM_KEY_LENGTH` check. Only the type-guard ordering was still outstanding.
