### PR TITLE
feat: add Model Context Protocol (MCP) server support

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
   "author": "Matthew Herod",
   "license": "ISC",
   "dependencies": {
+    "@modelcontextprotocol/sdk": "1.30.0",
     "better-sqlite3": "^12.4.1",
     "consola": "^3.4.2",
     "date-fns": "4.4.0",
@@ -93,6 +94,7 @@
     "jsonwebtoken": "^9.0.3",
     "lodash-es": "^4.17.23",
     "minimist": "^1.2.8",
+    "tldts": "7.4.12",
     "tsconfig-paths": "^4.2.0",
     "zod": "^4.1.11"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,9 @@ importers:
 
   .:
     dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: 1.30.0
+        version: 1.30.0(zod@4.4.3)
       better-sqlite3:
         specifier: ^12.4.1
         version: 12.10.0
@@ -43,6 +46,9 @@ importers:
       minimist:
         specifier: ^1.2.8
         version: 1.2.8
+      tldts:
+        specifier: 7.4.12
+        version: 7.4.12
       tsconfig-paths:
         specifier: ^4.2.0
         version: 4.2.0
@@ -804,6 +810,12 @@ packages:
   '@gerrit0/mini-shiki@3.23.0':
     resolution: {integrity: sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg==}
 
+  '@hono/node-server@2.1.1':
+    resolution: {integrity: sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      hono: ^4
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -958,6 +970,16 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+
+  '@modelcontextprotocol/sdk@1.30.0':
+    resolution: {integrity: sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@napi-rs/wasm-runtime@1.1.4':
     resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
@@ -1544,6 +1566,10 @@ packages:
   '@vueuse/shared@12.8.2':
     resolution: {integrity: sha512-dznP38YzxZoNloI0qpEfpkms8knDtaoQ6Y/sfS0L7Yki4zh40LFHEhur0odJC6xTHG5dxWVPiUWBXn+wCG2s5w==}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   acorn-jsx-walk@2.0.0:
     resolution: {integrity: sha512-uuo6iJj4D4ygkdzd6jPtcxs8vZgDX9YFIkqczGImoypX2fQ4dVImmu3UzA4ynixCIMTrEOWW+95M2HuBaCEOVA==}
 
@@ -1573,6 +1599,14 @@ packages:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
 
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
@@ -1739,6 +1773,10 @@ packages:
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
+  body-parser@2.3.0:
+    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
+    engines: {node: '>=18'}
+
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
 
@@ -1782,6 +1820,10 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     peerDependencies:
       esbuild: ^0.25.0
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
 
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
@@ -1943,6 +1985,18 @@ packages:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
 
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  content-type@2.1.0:
+    resolution: {integrity: sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==}
+    engines: {node: '>=18'}
+
   conventional-changelog-angular@8.2.0:
     resolution: {integrity: sha512-4YB1zEXqB17oBI8yRsAs1T+ZhbdsOgJqkl6Trz+GXt/eKf1e4jnA0oW+sOd9BEENzEViuNW0DNoFFjSf3CeC5Q==}
     engines: {node: '>=18'}
@@ -1959,9 +2013,21 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
   copy-anything@3.0.5:
     resolution: {integrity: sha512-yCEafptTtb4bk7GLEQoM8KVJpxAfdBJYaXyzQEgQQQgYrZiDp8SJmGKlYza6CYjEDNstAdNdKA3UuoULlEbS6w==}
     engines: {node: '>=12.13'}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
 
   cosmiconfig-typescript-loader@6.2.0:
     resolution: {integrity: sha512-GEN39v7TgdxgIoNcdkRE3uiAzQt3UXLyHbRHD6YoL048XAeOomyxaP+Hh/+2C6C2wYjxJ2onhJcsQp+L4YEkVQ==}
@@ -2059,6 +2125,10 @@ packages:
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
+
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
 
   dependency-cruiser@17.4.3:
     resolution: {integrity: sha512-L4GLuAvmXevWnPCIaFfOz6eD92c+yY+pDgVqgufrLDnW3xYA799CSZQlly2r2N13nhAlnZY6VzY7Rx5pHNvk2w==}
@@ -2161,6 +2231,9 @@ packages:
   ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
   electron-to-chromium@1.5.366:
     resolution: {integrity: sha512-OlRuhb688YTCzzU3gXPLn6nGyd+F+53INE1qaKKlu6kETErE8FYsyDh0XqXEU+uBRn0MpCzz2vfNwORhkap8qg==}
 
@@ -2179,6 +2252,10 @@ packages:
 
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
@@ -2238,6 +2315,9 @@ packages:
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
   escape-string-regexp@1.0.5:
     resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
@@ -2384,8 +2464,20 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+
+  eventsource-parser@3.1.1:
+    resolution: {integrity: sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
 
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
@@ -2406,6 +2498,16 @@ packages:
   expect@30.4.1:
     resolution: {integrity: sha512-PMARsyh/JtqC20HoGqlFcIlQAyqUtW4PlI1rup1uhYJtKuwAjbvWi3GQMAn+STdHum/dk8xrKfUM1+5SAwpolA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  express-rate-limit@8.7.0:
+    resolution: {integrity: sha512-hOwV7WOxXfjRpAM1DSJWZDXx3GhplwD8IfwuwvogD8i1Qnkgosw/H45s4ZnFAUHDAhPjlY9hLBvJhKmGMyY26g==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -2454,6 +2556,10 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
@@ -2482,6 +2588,14 @@ packages:
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
@@ -2650,6 +2764,10 @@ packages:
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
 
+  hono@4.13.7:
+    resolution: {integrity: sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ==}
+    engines: {node: '>=16.9.0'}
+
   hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
 
@@ -2662,6 +2780,10 @@ packages:
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+
   human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
@@ -2670,6 +2792,10 @@ packages:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
     engines: {node: '>=18'}
     hasBin: true
+
+  iconv-lite@0.7.3:
+    resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
+    engines: {node: '>=0.10.0'}
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -2719,6 +2845,14 @@ packages:
   interpret@3.1.1:
     resolution: {integrity: sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==}
     engines: {node: '>=10.13.0'}
+
+  ip-address@10.7.0:
+    resolution: {integrity: sha512-BGFsyJd5mpXp3rK6jIdADLNgpJUK1jnjzvYF8lK+VyDab9JAmqN0YOKDdP17HlgKb2+ehPgDc8EtnRLbGCAMhA==}
+    engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
 
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
@@ -2833,6 +2967,9 @@ packages:
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
@@ -3078,6 +3215,9 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
+  jose@6.2.12:
+    resolution: {integrity: sha512-9NiFmJEex0sy2Dk58j2UGBSHgUs2ypF9eZSu4L6vjOX3Dp96Sw1F3uL+H+D1sx02jZZdzUT0HgvCy59CuvXcWw==}
+
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
@@ -3113,6 +3253,9 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -3290,12 +3433,20 @@ packages:
   mdurl@2.0.0:
     resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
 
+  media-typer@1.1.1:
+    resolution: {integrity: sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==}
+    engines: {node: '>= 0.8'}
+
   meow@12.1.1:
     resolution: {integrity: sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw==}
     engines: {node: '>=16.10'}
 
   meow@13.2.0:
     resolution: {integrity: sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==}
+    engines: {node: '>=18'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
     engines: {node: '>=18'}
 
   merge-stream@2.0.0:
@@ -3323,6 +3474,14 @@ packages:
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
+
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
 
   mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
@@ -3405,6 +3564,10 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  negotiator@1.1.0:
+    resolution: {integrity: sha512-NMPBRMJgiQHjbd8phG3Vebdx4kZ1H121rbl5IkMqeOsahptB9BKo/d7oJ3zTXqTgagn2bWlNSXkh0QUGM31RYg==}
+    engines: {node: '>=18'}
+
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
@@ -3465,6 +3628,10 @@ packages:
   object.values@1.2.1:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
@@ -3533,6 +3700,10 @@ packages:
   parse-statements@1.0.11:
     resolution: {integrity: sha512-HlsyYdMBnbPQ9Jr/VgJ1YF4scnldvJpJxCVx6KgqPL4dxppsWrJHCIIxQXMJrqGnsRkNPATbeMJ8Yxu7JMsYcA==}
 
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -3551,6 +3722,9 @@ packages:
   path-scurry@1.11.1:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -3576,6 +3750,10 @@ packages:
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
@@ -3671,6 +3849,10 @@ packages:
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
@@ -3685,6 +3867,10 @@ packages:
   pure-rand@7.0.1:
     resolution: {integrity: sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==}
 
+  qs@6.16.0:
+    resolution: {integrity: sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==}
+    engines: {node: '>=0.6'}
+
   queue-lit@1.5.2:
     resolution: {integrity: sha512-tLc36IOPeMAubu8BkW8YDBV+WyIgKlYU7zUNs0J5Vk9skSZ4JfGlPOqplP0aHdfv7HL0B2Pg6nwiq60Qc6M2Hw==}
     engines: {node: '>=12'}
@@ -3694,6 +3880,14 @@ packages:
 
   quote-unquote@1.0.0:
     resolution: {integrity: sha512-twwRO/ilhlG/FIgYeKGFqyHhoEhqgnKVkcmqMKi2r524gz3ZbDTcyFt38E9xjJI2vT+KbRNHVbnJ/e0I25Azwg==}
+
+  range-parser@1.3.0:
+    resolution: {integrity: sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
@@ -3812,6 +4006,10 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -3832,6 +4030,9 @@ packages:
 
   safe-regex@2.1.1:
     resolution: {integrity: sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
   sass-lookup@6.1.0:
     resolution: {integrity: sha512-Zx+lVyoWqXZxHuYWlTA17Z5sczJ6braNT2C7rmClw+c4E7r/n911Zwss3h1uHI9reR5AgHZyNHF7c2+VIp5AUA==}
@@ -3860,6 +4061,14 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
     engines: {node: '>= 0.4'}
@@ -3871,6 +4080,9 @@ packages:
   set-proto@1.0.0:
     resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
     engines: {node: '>= 0.4'}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -3887,6 +4099,10 @@ packages:
     resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
     engines: {node: '>= 0.4'}
 
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
   side-channel-map@1.0.1:
     resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
     engines: {node: '>= 0.4'}
@@ -3897,6 +4113,10 @@ packages:
 
   side-channel@1.1.0:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
     engines: {node: '>= 0.4'}
 
   signal-exit@3.0.7:
@@ -3972,6 +4192,10 @@ packages:
   stack-utils@2.0.6:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
     engines: {node: '>=10'}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -4128,6 +4352,13 @@ packages:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
 
+  tldts-core@7.4.12:
+    resolution: {integrity: sha512-nYNzS2WRf4QJmjzFFgAxLOBjyBxAGRbCy9PVBPaglcYyYajh40VBn+v5Ngr96ZMc7oM0+aCJdtQnNejvdBnXMQ==}
+
+  tldts@7.4.12:
+    resolution: {integrity: sha512-WylhSDKVeYnWXL3a+vKTaOxjnOeEGw938hImY8zoRWJjRRK/Jp1K+IihBzIONpUmW4e3WmXT6q5FW6vlESVZCA==}
+    hasBin: true
+
   tmpl@1.0.5:
     resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
 
@@ -4138,6 +4369,10 @@ packages:
   to-valid-identifier@1.0.0:
     resolution: {integrity: sha512-41wJyvKep3yT2tyPqX/4blcfybknGB4D+oETKLs7Q76UiPqRpUJK3hr1nxelyYO0PHKVzJwlu0aCeEAsGI6rpw==}
     engines: {node: '>=20'}
+
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
 
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
@@ -4262,6 +4497,10 @@ packages:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
     engines: {node: '>=16'}
 
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
+
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
     engines: {node: '>= 0.4'}
@@ -4329,6 +4568,10 @@ packages:
   unist-util-visit@5.0.0:
     resolution: {integrity: sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==}
 
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
   unrs-resolver@1.12.2:
     resolution: {integrity: sha512-dmlRxBJJayXjqTwC+JtF1HhJmgf3ftQ3YejFcZrf4+KKtJv0qDsK1pjqaaVjG7wJ5NJ6UVP1OqRMQ71Z4C3rxQ==}
 
@@ -4350,6 +4593,10 @@ packages:
   v8-to-istanbul@9.3.0:
     resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
     engines: {node: '>=10.12.0'}
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   vfile-message@4.0.3:
     resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
@@ -4502,6 +4749,11 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
@@ -5179,6 +5431,10 @@ snapshots:
       '@shikijs/types': 3.23.0
       '@shikijs/vscode-textmate': 10.0.2
 
+  '@hono/node-server@2.1.1(hono@4.13.7)':
+    dependencies:
+      hono: 4.13.7
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.7':
@@ -5441,6 +5697,28 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@modelcontextprotocol/sdk@1.30.0(zod@4.4.3)':
+    dependencies:
+      '@hono/node-server': 2.1.1(hono@4.13.7)
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.1
+      express: 5.2.1
+      express-rate-limit: 8.7.0(express@5.2.1)
+      hono: 4.13.7
+      jose: 6.2.12
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
+    transitivePeerDependencies:
+      - supports-color
 
   '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
@@ -6004,6 +6282,11 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.1.0
+
   acorn-jsx-walk@2.0.0: {}
 
   acorn-jsx@5.3.2(acorn@8.16.0):
@@ -6025,6 +6308,10 @@ snapshots:
   acorn@8.15.0: {}
 
   acorn@8.16.0: {}
+
+  ajv-formats@3.0.1(ajv@8.18.0):
+    optionalDependencies:
+      ajv: 8.18.0
 
   ajv@6.12.6:
     dependencies:
@@ -6241,6 +6528,20 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
+  body-parser@2.3.0:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 2.1.0
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
+      on-finished: 2.4.1
+      qs: 6.16.0
+      raw-body: 3.0.2
+      type-is: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   brace-expansion@1.1.12:
     dependencies:
       balanced-match: 1.0.2
@@ -6292,6 +6593,8 @@ snapshots:
     dependencies:
       esbuild: 0.25.12
       load-tsconfig: 0.2.5
+
+  bytes@3.1.2: {}
 
   cac@6.7.14: {}
 
@@ -6429,6 +6732,12 @@ snapshots:
 
   consola@3.4.2: {}
 
+  content-disposition@1.1.0: {}
+
+  content-type@1.0.5: {}
+
+  content-type@2.1.0: {}
+
   conventional-changelog-angular@8.2.0:
     dependencies:
       compare-func: 2.0.0
@@ -6444,9 +6753,18 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
+
   copy-anything@3.0.5:
     dependencies:
       is-what: 4.1.16
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   cosmiconfig-typescript-loader@6.2.0(@types/node@25.9.1)(cosmiconfig@9.0.1(typescript@5.9.3))(typescript@5.9.3):
     dependencies:
@@ -6531,6 +6849,8 @@ snapshots:
       define-data-property: 1.1.4
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
+
+  depd@2.0.0: {}
 
   dependency-cruiser@17.4.3:
     dependencies:
@@ -6658,6 +6978,8 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  ee-first@1.1.1: {}
+
   electron-to-chromium@1.5.366: {}
 
   emittery@0.13.1: {}
@@ -6669,6 +6991,8 @@ snapshots:
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
+
+  encodeurl@2.0.0: {}
 
   end-of-stream@1.4.5:
     dependencies:
@@ -6801,6 +7125,8 @@ snapshots:
       '@esbuild/win32-x64': 0.25.12
 
   escalade@3.2.0: {}
+
+  escape-html@1.0.3: {}
 
   escape-string-regexp@1.0.5: {}
 
@@ -6995,7 +7321,15 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  etag@1.8.1: {}
+
   eventemitter3@5.0.4: {}
+
+  eventsource-parser@3.1.1: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.1.1
 
   execa@5.1.1:
     dependencies:
@@ -7030,6 +7364,47 @@ snapshots:
       jest-message-util: 30.4.1
       jest-mock: 30.4.1
       jest-util: 30.4.1
+
+  express-rate-limit@8.7.0(express@5.2.1):
+    dependencies:
+      debug: 4.4.3
+      express: 5.2.1
+      ip-address: 10.7.0
+    transitivePeerDependencies:
+      - supports-color
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.3.0
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.16.0
+      range-parser: 1.3.0
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.1.0
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   fast-deep-equal@3.1.3: {}
 
@@ -7083,6 +7458,17 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   find-up@4.1.0:
     dependencies:
       locate-path: 5.0.0
@@ -7118,6 +7504,10 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
+
+  forwarded@0.2.0: {}
+
+  fresh@2.0.0: {}
 
   fs-constants@1.0.0: {}
 
@@ -7303,6 +7693,8 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
 
+  hono@4.13.7: {}
+
   hookable@5.5.3: {}
 
   html-entities@2.6.0: {}
@@ -7311,9 +7703,21 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+
   human-signals@2.1.0: {}
 
   husky@9.1.7: {}
+
+  iconv-lite@0.7.3:
+    dependencies:
+      safer-buffer: 2.1.2
 
   ieee754@1.2.1: {}
 
@@ -7353,6 +7757,10 @@ snapshots:
       side-channel: 1.1.0
 
   interpret@3.1.1: {}
+
+  ip-address@10.7.0: {}
+
+  ipaddr.js@1.9.1: {}
 
   is-array-buffer@3.0.5:
     dependencies:
@@ -7458,6 +7866,8 @@ snapshots:
   is-path-inside@4.0.0: {}
 
   is-plain-obj@4.1.0: {}
+
+  is-promise@4.0.0: {}
 
   is-regex@1.2.1:
     dependencies:
@@ -7908,6 +8318,8 @@ snapshots:
 
   jiti@2.6.1: {}
 
+  jose@6.2.12: {}
+
   joycon@3.1.1: {}
 
   js-tokens@4.0.0: {}
@@ -7932,6 +8344,8 @@ snapshots:
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -8129,9 +8543,13 @@ snapshots:
 
   mdurl@2.0.0: {}
 
+  media-typer@1.1.1: {}
+
   meow@12.1.1: {}
 
   meow@13.2.0: {}
+
+  merge-descriptors@2.0.0: {}
 
   merge-stream@2.0.0: {}
 
@@ -8158,6 +8576,12 @@ snapshots:
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.2
+
+  mime-db@1.54.0: {}
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
 
   mimic-fn@2.1.0: {}
 
@@ -8228,6 +8652,10 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
+  negotiator@1.1.0:
+    dependencies:
+      content-type: 2.1.0
+
   neo-async@2.6.2: {}
 
   node-abi@3.92.0:
@@ -8287,6 +8715,10 @@ snapshots:
       call-bound: 1.0.4
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
 
   once@1.4.0:
     dependencies:
@@ -8372,6 +8804,8 @@ snapshots:
 
   parse-statements@1.0.11: {}
 
+  parseurl@1.3.3: {}
+
   path-exists@4.0.0: {}
 
   path-is-absolute@1.0.1: {}
@@ -8384,6 +8818,8 @@ snapshots:
     dependencies:
       lru-cache: 10.4.3
       minipass: 7.1.3
+
+  path-to-regexp@8.4.2: {}
 
   path-type@4.0.0: {}
 
@@ -8398,6 +8834,8 @@ snapshots:
   picomatch@4.0.4: {}
 
   pirates@4.0.7: {}
+
+  pkce-challenge@5.0.1: {}
 
   pkg-dir@4.2.0:
     dependencies:
@@ -8506,6 +8944,11 @@ snapshots:
 
   property-information@7.1.0: {}
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
   pump@3.0.4:
     dependencies:
       end-of-stream: 1.4.5
@@ -8517,11 +8960,25 @@ snapshots:
 
   pure-rand@7.0.1: {}
 
+  qs@6.16.0:
+    dependencies:
+      es-define-property: 1.0.1
+      side-channel: 1.1.1
+
   queue-lit@1.5.2: {}
 
   queue-microtask@1.2.3: {}
 
   quote-unquote@1.0.0: {}
+
+  range-parser@1.3.0: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
+      unpipe: 1.0.0
 
   rc@1.2.8:
     dependencies:
@@ -8662,6 +9119,16 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.53.3
       fsevents: 2.3.3
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -8691,6 +9158,8 @@ snapshots:
     dependencies:
       regexp-tree: 0.1.27
 
+  safer-buffer@2.1.2: {}
+
   sass-lookup@6.1.0:
     dependencies:
       commander: 12.1.0
@@ -8705,6 +9174,31 @@ snapshots:
   semver@7.7.4: {}
 
   semver@7.8.1: {}
+
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.3.0
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
 
   set-function-length@1.2.2:
     dependencies:
@@ -8728,6 +9222,8 @@ snapshots:
       es-errors: 1.3.0
       es-object-atoms: 1.1.1
 
+  setprototypeof@1.2.0: {}
+
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
@@ -8746,6 +9242,11 @@ snapshots:
       '@types/hast': 3.0.4
 
   side-channel-list@1.0.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-list@1.0.1:
     dependencies:
       es-errors: 1.3.0
       object-inspect: 1.13.4
@@ -8770,6 +9271,14 @@ snapshots:
       es-errors: 1.3.0
       object-inspect: 1.13.4
       side-channel-list: 1.0.0
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
+  side-channel@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
@@ -8832,6 +9341,8 @@ snapshots:
   stack-utils@2.0.6:
     dependencies:
       escape-string-regexp: 2.0.0
+
+  statuses@2.0.2: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -9011,6 +9522,12 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
+  tldts-core@7.4.12: {}
+
+  tldts@7.4.12:
+    dependencies:
+      tldts-core: 7.4.12
+
   tmpl@1.0.5: {}
 
   to-regex-range@5.0.1:
@@ -9021,6 +9538,8 @@ snapshots:
     dependencies:
       '@sindresorhus/base62': 1.0.0
       reserved-identifiers: 1.2.0
+
+  toidentifier@1.0.1: {}
 
   tree-kill@1.2.2: {}
 
@@ -9159,6 +9678,12 @@ snapshots:
 
   type-fest@4.41.0: {}
 
+  type-is@2.1.0:
+    dependencies:
+      content-type: 2.1.0
+      media-typer: 1.1.1
+      mime-types: 3.0.2
+
   typed-array-buffer@1.0.3:
     dependencies:
       call-bound: 1.0.4
@@ -9246,6 +9771,8 @@ snapshots:
       unist-util-is: 6.0.0
       unist-util-visit-parents: 6.0.1
 
+  unpipe@1.0.0: {}
+
   unrs-resolver@1.12.2:
     dependencies:
       napi-postinstall: 0.3.4
@@ -9292,6 +9819,8 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
+
+  vary@1.1.2: {}
 
   vfile-message@4.0.3:
     dependencies:
@@ -9480,6 +10009,10 @@ snapshots:
   yn@3.1.1: {}
 
   yocto-queue@0.1.0: {}
+
+  zod-to-json-schema@3.25.2(zod@4.4.3):
+    dependencies:
+      zod: 4.4.3
 
   zod@4.4.3: {}
 

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -24,6 +24,7 @@ declare const BUILD_TIMESTAMP: string;
 
 function showHelp(): void {
   logger.log("Usage: get-cookie [name] [domain] [options]");
+  logger.log("       get-cookie mcp --allow-origin https://example.com");
 
   // Show build info if available
   if (typeof BUILD_TIMESTAMP !== "undefined") {
@@ -245,6 +246,20 @@ async function handleCookieQuery(
 async function main(): Promise<void> {
   const args = process.argv.slice(2);
 
+  if (args[0] === "mcp") {
+    const { parseMcpArgs } = await import("../mcp/policy");
+    const policy = parseMcpArgs(args.slice(1));
+    if (policy.help) {
+      process.stderr.write(
+        "Usage: get-cookie mcp [--allow-origin https://example.com] [--allow-cookie-values] [--allow-unsafe-methods]\nRepeat --allow-origin for each origin. Without it only profile discovery is available. HTTP is allowed only on loopback.\n",
+      );
+      return;
+    }
+    const { startMcpServer } = await import("../mcp/server");
+    await startMcpServer(policy);
+    return;
+  }
+
   // Show help if no arguments provided
   if (args.length === 0) {
     showHelp();
@@ -269,6 +284,10 @@ async function main(): Promise<void> {
 }
 
 main().catch((error) => {
+  if (process.argv[2] === "mcp") {
+    process.stderr.write(`get-cookie MCP: ${getErrorMessage(error)}\n`);
+    process.exit(1);
+  }
   logger.error("Fatal error:", getErrorMessage(error));
   process.exit(1);
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,7 +4,7 @@ import { config } from "dotenv";
 import { z } from "zod";
 
 // Load environment variables from .env file
-config();
+config({ quiet: true });
 
 const EnvironmentSchema = z.object({
   LOG_LEVEL: z.enum(["debug", "info", "warn", "error"]).default("info"),

--- a/src/core/browsers/chrome/__tests__/decrypt.raw.test.ts
+++ b/src/core/browsers/chrome/__tests__/decrypt.raw.test.ts
@@ -1,0 +1,29 @@
+import { createCipheriv, pbkdf2Sync } from "node:crypto";
+
+import { withRawCookieValues } from "../../../cookies/CookieQueryContext";
+import { decrypt } from "../decrypt";
+
+jest.mock("@utils/platformUtils", () => ({
+  isMacOS: () => true,
+  isWindows: () => false,
+}));
+
+it("preserves full authentication values without changing concurrent display queries", async () => {
+  const value = "prefix-12345678-1234-1234-1234-123456789abc-suffix";
+  const cipher = createCipheriv(
+    "aes-128-cbc",
+    pbkdf2Sync("password", "saltysalt", 1003, 16, "sha1"),
+    Buffer.alloc(16, " "),
+  );
+  const encrypted = Buffer.concat([
+    Buffer.from("v10"),
+    cipher.update(value),
+    cipher.final(),
+  ]);
+  const [raw, display] = await Promise.all([
+    withRawCookieValues(async () => decrypt(encrypted, "password")),
+    decrypt(encrypted, "password"),
+  ]);
+  expect(raw).toBe(value);
+  expect(display).toBe("12345678-1234-1234-1234-123456789abc");
+});

--- a/src/core/browsers/chrome/decrypt.ts
+++ b/src/core/browsers/chrome/decrypt.ts
@@ -3,6 +3,8 @@ import { createDecipheriv, pbkdf2 } from "node:crypto";
 
 import { isMacOS, isWindows } from "@utils/platformUtils";
 
+import { usesRawCookieValues } from "../../cookies/CookieQueryContext";
+
 /**
  * Simple memoization utility for caching Buffer operations
  * @param fn - The function to memoize that takes a Buffer and returns a Buffer
@@ -273,7 +275,7 @@ export async function decrypt(
         : decrypted;
 
     const decodedString = finalDecrypted.toString("utf8");
-    return extractValue(decodedString);
+    return usesRawCookieValues() ? decodedString : extractValue(decodedString);
   } catch (e) {
     // Preserve the specific finalize-failure message; wrap anything else.
     if (

--- a/src/core/browsers/chromium/BaseChromiumCookieQueryStrategy.ts
+++ b/src/core/browsers/chromium/BaseChromiumCookieQueryStrategy.ts
@@ -7,15 +7,71 @@ import type {
   CookieSpec,
   ExportedCookie,
 } from "../../../types/schemas";
+import type { CookieMeta } from "../../../types/schemas";
 import { chromeTimestampToDate } from "../../../utils/chromeDates";
+import { usesRawCookieValues } from "../../cookies/CookieQueryContext";
 import { BaseCookieQueryStrategy } from "../BaseCookieQueryStrategy";
 import { BrowserLockHandler } from "../BrowserLockHandler";
 import type { ChromiumBrowser } from "../chrome/ChromiumBrowsers";
 import { decrypt } from "../chrome/decrypt";
 import { getChromiumPassword } from "../chrome/getChromiumPassword";
+import type { SqliteDatabase } from "../sql/adapters/DatabaseAdapter";
 import { CookieQueryBuilder, isSqlBrowser } from "../sql/CookieQueryBuilder";
 import { getGlobalConnectionManager } from "../sql/DatabaseConnectionManager";
 import { getGlobalQueryMonitor } from "../sql/QueryMonitor";
+
+interface ChromiumQueryRow {
+  encrypted_value: Buffer;
+  plaintext_value?: string;
+  name: string;
+  domain: string;
+  expiry: number;
+  path?: string;
+  is_secure?: number;
+  is_httponly?: number;
+  top_frame_site_key?: string;
+}
+
+type RequestCookieRow = CookieRow & { requestMeta?: CookieMeta };
+
+function rawCookieSql(db: SqliteDatabase, sql: string): string {
+  if (!usesRawCookieValues()) {
+    return sql;
+  }
+  const columns = db.prepare("PRAGMA table_info(cookies)").all() as {
+    name: string;
+  }[];
+  const partition = columns.some(
+    (column) => column.name === "top_frame_site_key",
+  )
+    ? "top_frame_site_key"
+    : "'' AS top_frame_site_key";
+  return sql.replace(
+    "SELECT ",
+    `SELECT value AS plaintext_value, ${partition}, `,
+  );
+}
+
+function toCookieRow(row: ChromiumQueryRow): RequestCookieRow {
+  return {
+    name: row.name,
+    domain: row.domain,
+    expiry: row.expiry,
+    value:
+      usesRawCookieValues() && !row.encrypted_value?.length
+        ? (row.plaintext_value ?? "")
+        : row.encrypted_value,
+    ...(usesRawCookieValues() && {
+      requestMeta: {
+        ...(row.path !== undefined && { path: row.path }),
+        secure: row.is_secure === 1,
+        httpOnly: row.is_httponly === 1,
+        hostOnly: !row.domain.startsWith("."),
+        partitioned: Boolean(row.top_frame_site_key),
+      },
+    }),
+  };
+}
 
 interface DecryptionContext {
   file: string;
@@ -195,21 +251,14 @@ export abstract class BaseChromiumCookieQueryStrategy extends BaseCookieQueryStr
       const encryptedCookies = await connectionManager.executeQuery(
         file,
         (db) => {
-          const rows = monitor.executeQuery<{
-            encrypted_value: Buffer;
-            name: string;
-            domain: string;
-            expiry: number;
-          }>(db, queryConfig.sql, queryConfig.params, file);
-
-          return rows.map(
-            (row): CookieRow => ({
-              name: row.name,
-              domain: row.domain,
-              value: row.encrypted_value,
-              expiry: row.expiry,
-            }),
+          const rows = monitor.executeQuery<ChromiumQueryRow>(
+            db,
+            rawCookieSql(db, queryConfig.sql),
+            queryConfig.params,
+            file,
           );
+
+          return rows.map(toCookieRow);
         },
         queryConfig.description || queryConfig.sql,
       );
@@ -506,22 +555,15 @@ export abstract class BaseChromiumCookieQueryStrategy extends BaseCookieQueryStr
         file,
         (db) => {
           // The CookieQueryBuilder aliases columns, so we get 'domain' not 'host_key'
-          const rows = monitor.executeQuery<{
-            encrypted_value: Buffer;
-            name: string;
-            domain: string;
-            expiry: number;
-          }>(db, queryConfig.sql, queryConfig.params, file);
+          const rows = monitor.executeQuery<ChromiumQueryRow>(
+            db,
+            rawCookieSql(db, queryConfig.sql),
+            queryConfig.params,
+            file,
+          );
 
           // Transform to CookieRow format
-          return rows.map(
-            (row): CookieRow => ({
-              name: row.name,
-              domain: row.domain,
-              value: row.encrypted_value,
-              expiry: row.expiry,
-            }),
-          );
+          return rows.map(toCookieRow);
         },
         queryConfig.sql,
       );
@@ -593,7 +635,7 @@ export abstract class BaseChromiumCookieQueryStrategy extends BaseCookieQueryStr
    * @returns Exported cookie
    */
   protected async processCookie(
-    cookie: CookieRow,
+    cookie: RequestCookieRow,
     context: DecryptionContext,
   ): Promise<ExportedCookie> {
     try {
@@ -601,13 +643,12 @@ export abstract class BaseChromiumCookieQueryStrategy extends BaseCookieQueryStr
         ? cookie.value
         : Buffer.from(String(cookie.value));
 
-      const decryptedValue = await decrypt(
-        value,
-        context.password,
-        context.metaVersion,
-      );
+      const decryptedValue =
+        usesRawCookieValues() && typeof cookie.value === "string"
+          ? cookie.value
+          : await decrypt(value, context.password, context.metaVersion);
 
-      return createExportedCookie(
+      const exported = createExportedCookie(
         cookie.domain,
         cookie.name,
         decryptedValue,
@@ -616,6 +657,10 @@ export abstract class BaseChromiumCookieQueryStrategy extends BaseCookieQueryStr
         context.browser,
         true,
       );
+      if (cookie.requestMeta && exported.meta) {
+        Object.assign(exported.meta, cookie.requestMeta);
+      }
+      return exported;
     } catch (error) {
       this.logger.warn(`Failed to decrypt ${context.browser} cookie`, {
         error: this.getErrorMessage(error),

--- a/src/core/browsers/firefox/FirefoxCookieQueryStrategy.ts
+++ b/src/core/browsers/firefox/FirefoxCookieQueryStrategy.ts
@@ -9,12 +9,14 @@ import { getPlatform } from "@utils/platformUtils";
 import { isFirefoxRunning } from "@utils/processDetector";
 
 import type { ExportedCookie } from "../../../types/schemas";
+import { usesRawCookieValues } from "../../cookies/CookieQueryContext";
 import { BaseCookieQueryStrategy } from "../BaseCookieQueryStrategy";
 import { FIREFOX_DATA_DIRS } from "../BrowserAvailability";
 import { BrowserLockHandler } from "../BrowserLockHandler";
 import { fileExists, readTextFile } from "../runtime/FileSystemAdapter";
 import { getGlobalConnectionManager } from "../sql/DatabaseConnectionManager";
 import { getGlobalQueryMonitor } from "../sql/QueryMonitor";
+
 import {
   extractUserContextId,
   resolveFirefoxContainer,
@@ -26,6 +28,9 @@ interface FirefoxCookieRow {
   domain: string;
   expiry: number | null;
   originAttributes?: string | null;
+  path?: string;
+  is_secure?: number;
+  is_httponly?: number;
 }
 
 /**
@@ -457,6 +462,15 @@ export class FirefoxCookieQueryStrategy extends BaseCookieQueryStrategy {
             file,
             browser: "Firefox",
             decrypted: false,
+            ...(usesRawCookieValues() && {
+              ...(row.path !== undefined && { path: row.path }),
+              secure: row.is_secure === 1,
+              httpOnly: row.is_httponly === 1,
+              hostOnly: !row.domain.startsWith("."),
+              partitioned: /(?:partitionKey|firstPartyDomain)=([^&]+)/.test(
+                row.originAttributes ?? "",
+              ),
+            }),
             ...(userContextId !== undefined && { containerId: userContextId }),
           },
         };

--- a/src/core/browsers/safari/BinaryCodableCookie.ts
+++ b/src/core/browsers/safari/BinaryCodableCookie.ts
@@ -5,6 +5,7 @@ import {
   BinaryCookieRowSchema,
 } from "../../../types/schemas";
 import { createTaggedLogger } from "../../../utils/logHelpers";
+import { usesRawCookieValues } from "../../cookies/CookieQueryContext";
 
 import type { BinaryCodableContainer } from "./interfaces/BinaryCodableContainer";
 import type { BinaryCodableFlags } from "./interfaces/BinaryCodableFlags";
@@ -312,6 +313,11 @@ export class BinaryCodableCookie {
         commentURL: this.commentURL,
       });
 
+      // Preserve the bytes represented by the stored string for HTTP consumers.
+      // The ordinary schema intentionally decodes values for display.
+      if (usesRawCookieValues()) {
+        cookieRow.value = this.value;
+      }
       return cookieRow;
     } catch (_error) {
       return null;

--- a/src/core/browsers/safari/SafariCookieQueryStrategy.ts
+++ b/src/core/browsers/safari/SafariCookieQueryStrategy.ts
@@ -10,6 +10,7 @@ import {
 } from "@utils/systemPermissions";
 
 import type { ExportedCookie } from "../../../types/schemas";
+import { usesRawCookieValues } from "../../cookies/CookieQueryContext";
 import { BaseCookieQueryStrategy } from "../BaseCookieQueryStrategy";
 import { BrowserLockHandler } from "../BrowserLockHandler";
 import { fileExists } from "../runtime/FileSystemAdapter";
@@ -387,7 +388,9 @@ export class SafariCookieQueryStrategy extends BaseCookieQueryStrategy {
     return {
       domain: this.formatDomain(cookieObj.domain),
       name: cookieObj.name,
-      value: this.processValue(cookieObj.value),
+      value: usesRawCookieValues()
+        ? cookieObj.value
+        : this.processValue(cookieObj.value),
       expiry: this.formatExpiry(cookieObj.expiry),
       meta: {
         file: cookieDbPath,

--- a/src/core/cookies/CookieQueryContext.ts
+++ b/src/core/cookies/CookieQueryContext.ts
@@ -1,0 +1,22 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+// Request-local options keep machine consumers from receiving display-decoded
+// values without changing the existing CLI/library presentation behaviour.
+const context = new AsyncLocalStorage<{ rawValues: boolean }>();
+
+/**
+ *
+ */
+export function usesRawCookieValues(): boolean {
+  return context.getStore()?.rawValues === true;
+}
+
+/**
+ *
+ * @param operation
+ */
+export async function withRawCookieValues<T>(
+  operation: () => Promise<T>,
+): Promise<T> {
+  return context.run({ rawValues: true }, operation);
+}

--- a/src/core/cookies/CookieQueryContext.ts
+++ b/src/core/cookies/CookieQueryContext.ts
@@ -5,15 +5,19 @@ import { AsyncLocalStorage } from "node:async_hooks";
 const context = new AsyncLocalStorage<{ rawValues: boolean }>();
 
 /**
+ * Checks whether the current async context requires raw cookie values.
  *
+ * @returns True if raw cookie values should be preserved, false otherwise.
  */
 export function usesRawCookieValues(): boolean {
   return context.getStore()?.rawValues === true;
 }
 
 /**
+ * Executes an asynchronous operation with raw cookie values preserved.
  *
- * @param operation
+ * @param operation - The asynchronous callback to execute within this context.
+ * @returns The resolved result of the operation.
  */
 export async function withRawCookieValues<T>(
   operation: () => Promise<T>,

--- a/src/mcp/__tests__/cookies.test.ts
+++ b/src/mcp/__tests__/cookies.test.ts
@@ -1,0 +1,136 @@
+import type { ExportedCookie } from "../../types/schemas";
+import {
+  cookieDomains,
+  cookieHeader,
+  cookieMatchesUrl,
+  selectCookies,
+} from "../cookies";
+import { assertAllowedUrl, parseMcpArgs } from "../policy";
+
+const url = new URL("https://app.example.com/api/me");
+const cookie = (overrides: Partial<ExportedCookie> = {}): ExportedCookie => ({
+  name: "session",
+  value: "secret%3D",
+  domain: ".example.com",
+  expiry: "Infinity",
+  meta: { path: "/", file: "profile-one", browser: "Firefox", secure: true },
+  ...overrides,
+});
+
+describe("MCP cookie scoping", () => {
+  it("stops parent queries at public and private suffixes", () => {
+    expect(cookieDomains("app.example.co.uk")).toEqual([
+      "app.example.co.uk",
+      "example.co.uk",
+    ]);
+    expect(cookieDomains("foo.github.io")).toEqual(["foo.github.io"]);
+    expect(cookieDomains("127.0.0.1")).toEqual(["127.0.0.1"]);
+  });
+  it("checks host-only, domain boundaries, path boundaries, Secure, expiry and partitions", () => {
+    expect(cookieMatchesUrl(cookie(), url)).toBe(true);
+    for (const invalid of [
+      cookie({ domain: "example.com" }),
+      cookie({ domain: ".com" }),
+      cookie({ domain: ".ample.com" }),
+      cookie({ expiry: new Date(0) }),
+      cookie({ meta: { path: "/ap", browser: "Firefox" } }),
+      cookie({ meta: { browser: "Firefox" } }),
+      cookie({ meta: { path: "/", browser: "Firefox", partitioned: true } }),
+      cookie({ meta: { path: "/", browser: "Chrome", decrypted: false } }),
+    ]) {
+      expect(cookieMatchesUrl(invalid, url)).toBe(false);
+    }
+    expect(
+      cookieMatchesUrl(cookie(), new URL("http://app.example.com/api/me")),
+    ).toBe(false);
+    expect(
+      cookieMatchesUrl(
+        cookie({ meta: { path: "/api", browser: "Firefox" } }),
+        url,
+      ),
+    ).toBe(true);
+  });
+  it("deduplicates overlapping queries and orders longer paths first without combining sources", async () => {
+    const root = cookie();
+    const api = cookie({ meta: { ...root.meta, path: "/api" } });
+    const selected = await selectCookies(
+      url,
+      { browser: "firefox" },
+      async () => [root, api, root],
+    );
+    expect(selected).toEqual([api, root]);
+    expect(cookieHeader(selected)).toBe("session=secret%3D; session=secret%3D");
+    expect(() =>
+      cookieHeader([
+        root,
+        cookie({ meta: { ...root.meta, file: "profile-two" } }),
+      ]),
+    ).toThrow("multiple profiles");
+    expect(() =>
+      cookieHeader([root, cookie({ meta: { ...root.meta, containerId: 2 } })]),
+    ).toThrow("multiple profiles");
+  });
+  it("rejects header injection, conflicts and empty results", async () => {
+    for (const value of [
+      "x; other=secret",
+      "x\r\nHost: elsewhere",
+      "x\u0000",
+    ]) {
+      expect(() => cookieHeader([cookie({ value })])).toThrow("safely");
+    }
+    expect(() => cookieHeader([cookie({ name: "a=b" })])).toThrow("safely");
+    expect(() => cookieHeader([])).toThrow("No readable");
+    await expect(
+      selectCookies(url, { browser: "firefox" }, async () => [
+        cookie(),
+        cookie({ value: "other" }),
+      ]),
+    ).rejects.toThrow("Conflicting");
+  });
+  it("post-filters exact names even when SQL interprets wildcard characters", async () => {
+    const selected = await selectCookies(
+      url,
+      { browser: "firefox", name: "a_b" },
+      async () => [cookie({ name: "acb" }), cookie({ name: "a_b" })],
+    );
+    expect(selected.map((row) => row.name)).toEqual(["a_b"]);
+  });
+});
+
+describe("startup policy", () => {
+  it("requires an exact enabled origin with matching scheme and port", () => {
+    const policy = parseMcpArgs([
+      "--allow-origin",
+      "https://app.example.com",
+      "--allow-origin",
+      "http://127.0.0.1:8080",
+    ]);
+    expect(assertAllowedUrl(url.href, policy).origin).toBe(url.origin);
+    for (const denied of [
+      "https://app.example.com:444/",
+      "https://other.example.com/",
+      "http://app.example.com/",
+      "https://app.example.com.evil.test/",
+    ]) {
+      expect(() => assertAllowedUrl(denied, policy)).toThrow("Origin");
+    }
+    expect(() => assertAllowedUrl(url.href, parseMcpArgs([]))).toThrow(
+      "Origin",
+    );
+  });
+  it("rejects unsafe protocols, userinfo, fragments, wildcard origins and unknown arguments", () => {
+    for (const origin of [
+      "file:///tmp/file",
+      "https://user:pass@example.com",
+      "https://example.com/#x",
+      "https://example.com/path",
+      "http://example.com",
+      "https://*.example.com",
+    ]) {
+      expect(() => parseMcpArgs(["--allow-origin", origin])).toThrow();
+    }
+    expect(() =>
+      parseMcpArgs(["--allow-orign", "https://example.com"]),
+    ).toThrow();
+  });
+});

--- a/src/mcp/__tests__/fetch.test.ts
+++ b/src/mcp/__tests__/fetch.test.ts
@@ -1,0 +1,122 @@
+import { jest } from "@jest/globals";
+
+import type { CookieReader } from "../cookies";
+import { authenticatedFetch, type FetchInput } from "../fetch";
+import { parseMcpArgs } from "../policy";
+
+const policy = parseMcpArgs(["--allow-origin", "https://example.com"]);
+const input: FetchInput = {
+  url: "https://example.com/api/me",
+  browser: "firefox",
+  method: "GET",
+  timeoutMs: 1000,
+  maxResponseBytes: 5,
+};
+const reader: CookieReader = async () => [
+  {
+    domain: "example.com",
+    name: "session",
+    value: "secret%3D",
+    meta: { browser: "Firefox", file: "one", path: "/api", secure: true },
+  },
+];
+
+describe("authenticated fetch", () => {
+  it("sends scoped raw cookies, bounds the body and omits credential-bearing headers", async () => {
+    const request = jest.fn<typeof fetch>().mockResolvedValue(
+      new Response("abcdef", {
+        headers: {
+          "set-cookie": "new=secret",
+          "content-type": "text/plain",
+          "x-token": "private",
+        },
+      }),
+    );
+    const result = await authenticatedFetch(input, policy, reader, request);
+    const options = request.mock.calls[0]?.[1];
+    expect(new Headers(options?.headers).get("cookie")).toBe(
+      "session=secret%3D",
+    );
+    expect(options?.redirect).toBe("manual");
+    expect(result).toMatchObject({
+      body: "abcde",
+      bytes: 5,
+      truncated: true,
+      cookiesSent: 1,
+    });
+    expect(result.headers).toEqual({ "content-type": "text/plain" });
+  });
+  it("returns redirects without issuing another request", async () => {
+    const request = jest.fn<typeof fetch>().mockResolvedValue(
+      new Response(null, {
+        status: 302,
+        headers: { location: "https://evil.test", "set-cookie": "secret=x" },
+      }),
+    );
+    expect(
+      await authenticatedFetch(input, policy, reader, request),
+    ).toMatchObject({ status: 302, redirect: true });
+    expect(request).toHaveBeenCalledTimes(1);
+  });
+  it("blocks disallowed origins, methods and headers before reading cookies", async () => {
+    const read = jest.fn(reader);
+    for (const change of [
+      { url: "https://evil.test" },
+      { method: "POST" },
+      { headers: { Cookie: "injected" } },
+      { headers: { Host: "evil.test" } },
+      { body: "unexpected" },
+    ]) {
+      await expect(
+        authenticatedFetch({ ...input, ...change }, policy, read),
+      ).rejects.toThrow();
+    }
+    expect(read).not.toHaveBeenCalled();
+  });
+  it("supports explicitly enabled POST requests and returns HTTP errors as data", async () => {
+    const request = jest
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response("denied", { status: 403 }));
+    const result = await authenticatedFetch(
+      {
+        ...input,
+        method: "POST",
+        body: "{}",
+        headers: { "content-type": "application/json" },
+      },
+      { ...policy, allowUnsafeMethods: true },
+      reader,
+      request,
+    );
+    expect(result.status).toBe(403);
+    expect(result.ok).toBe(false);
+    expect(request.mock.calls[0]?.[1]?.body).toBe("{}");
+  });
+  it("never fetches without cookies or after cancellation", async () => {
+    const request = jest.fn<typeof fetch>();
+    await expect(
+      authenticatedFetch(input, policy, async () => [], request),
+    ).rejects.toThrow("No readable");
+    const controller = new AbortController();
+    controller.abort();
+    await expect(
+      authenticatedFetch(input, policy, reader, request, controller.signal),
+    ).rejects.toThrow();
+    expect(request).not.toHaveBeenCalled();
+  });
+  it("cancels a stalled response body at the timeout", async () => {
+    const request: typeof fetch = async (_url, options) =>
+      new Response(
+        new ReadableStream({
+          start(controller) {
+            options?.signal?.addEventListener("abort", () =>
+              controller.error(new Error("aborted")),
+            );
+          },
+        }),
+      );
+    await expect(
+      authenticatedFetch({ ...input, timeoutMs: 20 }, policy, reader, request),
+    ).rejects.toThrow("timed out");
+  });
+});

--- a/src/mcp/cookies.ts
+++ b/src/mcp/cookies.ts
@@ -1,0 +1,229 @@
+import { isIP } from "node:net";
+
+import { getDomain } from "tldts";
+
+import { createStrategy } from "../core/browsers/StrategyFactory";
+import { withRawCookieValues } from "../core/cookies/CookieQueryContext";
+import type { ExportedCookie } from "../types/schemas";
+
+import { McpOperationError } from "./policy";
+
+/**
+ *
+ */
+export interface CookieSelection {
+  browser: string;
+  profile?: string | undefined;
+  container?: string | number | undefined;
+  name?: string | undefined;
+}
+
+/**
+ *
+ */
+export type CookieReader = (
+  url: URL,
+  selection: CookieSelection,
+) => Promise<ExportedCookie[]>;
+
+/**
+ *
+ * @param host
+ */
+export function cookieDomains(host: string): string[] {
+  const domains = [host];
+  const registrable = getDomain(host, { allowPrivateDomains: true });
+  if (!registrable || isIP(host)) {
+    return domains;
+  }
+  let current = host;
+  while (current !== registrable && current.includes(".")) {
+    current = current.slice(current.indexOf(".") + 1);
+    domains.push(current);
+  }
+  return domains;
+}
+
+/**
+ *
+ * @param url
+ * @param selection
+ */
+export const readCookies: CookieReader = async (url, selection) => {
+  if (selection.browser === "safari" && selection.profile) {
+    throw new McpOperationError("Safari does not support named profiles.");
+  }
+  if (selection.container !== undefined && selection.browser !== "firefox") {
+    throw new McpOperationError("Containers are supported only by Firefox.");
+  }
+  return withRawCookieValues(async () => {
+    const strategy = createStrategy({
+      browser: selection.browser,
+      ...(selection.profile !== undefined && { profile: selection.profile }),
+      ...(selection.browser === "firefox" && {
+        container: selection.container ?? "none",
+      }),
+    });
+    const cookies: ExportedCookie[] = [];
+    for (const domain of cookieDomains(url.hostname)) {
+      // force=true suppresses interactive browser-close/permission prompts in
+      // the existing strategies. MCP stdin belongs exclusively to the protocol.
+      cookies.push(
+        ...(await strategy.queryCookies(
+          selection.name ?? "%",
+          domain,
+          undefined,
+          true,
+        )),
+      );
+    }
+    return cookies;
+  });
+};
+
+/**
+ *
+ * @param cookie
+ * @param url
+ * @param now
+ */
+export function cookieMatchesUrl(
+  cookie: ExportedCookie,
+  url: URL,
+  now = Date.now(),
+): boolean {
+  const domain = cookie.domain.toLowerCase();
+  const bareDomain = domain.replace(/^\./, "");
+  const hostOnly = cookie.meta?.hostOnly !== false && !domain.startsWith(".");
+  if (
+    hostOnly
+      ? url.hostname !== bareDomain
+      : !(
+          url.hostname === bareDomain ||
+          (!isIP(url.hostname) && url.hostname.endsWith(`.${bareDomain}`))
+        )
+  ) {
+    return false;
+  }
+  // Reject cookies whose domain is a public/private suffix, even if a corrupt
+  // local database contains such a row.
+  if (
+    domain.startsWith(".") &&
+    !getDomain(bareDomain, { allowPrivateDomains: true })
+  ) {
+    return false;
+  }
+  if (cookie.meta?.secure && url.protocol !== "https:") {
+    return false;
+  }
+  if (cookie.meta?.partitioned) {
+    return false;
+  }
+  const path = cookie.meta?.path;
+  if (!path?.startsWith("/")) {
+    return false;
+  }
+  if (
+    url.pathname !== path &&
+    !(
+      url.pathname.startsWith(path) &&
+      (path.endsWith("/") || url.pathname[path.length] === "/")
+    )
+  ) {
+    return false;
+  }
+  const expiry = cookie.expiry;
+  if (expiry instanceof Date && !(expiry.getTime() > now)) {
+    return false;
+  }
+  if (typeof expiry === "number" && !(expiry * 1000 > now)) {
+    return false;
+  }
+  if (typeof cookie.value !== "string") {
+    return false;
+  }
+  if (
+    cookie.meta?.browser !== "Firefox" &&
+    cookie.meta?.browser !== "Safari" &&
+    cookie.meta?.decrypted !== true
+  ) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ *
+ * @param url
+ * @param selection
+ * @param reader
+ */
+export async function selectCookies(
+  url: URL,
+  selection: CookieSelection,
+  reader: CookieReader,
+): Promise<ExportedCookie[]> {
+  const rows = await reader(url, selection);
+  const candidates = rows.filter(
+    (cookie) =>
+      cookieMatchesUrl(cookie, url) &&
+      (selection.name === undefined || cookie.name === selection.name),
+  );
+  const unique = new Map<string, ExportedCookie>();
+  for (const cookie of candidates) {
+    const key = JSON.stringify([
+      cookie.meta?.file,
+      cookie.meta?.containerId,
+      cookie.domain,
+      cookie.name,
+      cookie.meta?.path,
+    ]);
+    if (unique.has(key) && unique.get(key)?.value !== cookie.value) {
+      throw new McpOperationError(
+        "Conflicting cookies found. Select one browser profile and container.",
+      );
+    }
+    unique.set(key, cookie);
+  }
+  return [...unique.values()].sort(
+    (a, b) => (b.meta?.path?.length ?? 0) - (a.meta?.path?.length ?? 0),
+  );
+}
+
+/**
+ *
+ * @param cookies
+ */
+export function cookieHeader(cookies: ExportedCookie[]): string {
+  if (cookies.length === 0) {
+    throw new McpOperationError(
+      "No readable, applicable cookies found. Check the browser, profile, container and local permissions.",
+    );
+  }
+  const sources = new Set(
+    cookies.map((cookie) =>
+      JSON.stringify([cookie.meta?.file, cookie.meta?.containerId ?? 0]),
+    ),
+  );
+  if (sources.size !== 1) {
+    throw new McpOperationError(
+      "Cookies span multiple profiles or containers. Select one profile and container before fetching.",
+    );
+  }
+  const pairs = cookies.map((cookie) => {
+    if (
+      !/^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/.test(cookie.name) ||
+      !/^[\x21\x23-\x2B\x2D-\x3A\x3C-\x5B\x5D-\x7E]*$/.test(cookie.value)
+    ) {
+      throw new McpOperationError(
+        "A cookie cannot be represented safely in an HTTP Cookie header.",
+      );
+    }
+    return `${cookie.name}=${cookie.value}`;
+  });
+  const header = pairs.join("; ");
+  if (Buffer.byteLength(header) > 65536) {
+    throw new McpOperationError("Cookie header exceeds 64 KiB.");
+  }
+  return header;
+}

--- a/src/mcp/cookies.ts
+++ b/src/mcp/cookies.ts
@@ -9,7 +9,7 @@ import type { ExportedCookie } from "../types/schemas";
 import { McpOperationError } from "./policy";
 
 /**
- *
+ * Parameters for selecting cookies from a specific browser and store.
  */
 export interface CookieSelection {
   browser: string;
@@ -19,7 +19,7 @@ export interface CookieSelection {
 }
 
 /**
- *
+ * Function signature for reading cookies given a target URL and selection criteria.
  */
 export type CookieReader = (
   url: URL,
@@ -27,8 +27,10 @@ export type CookieReader = (
 ) => Promise<ExportedCookie[]>;
 
 /**
+ * Computes the domain hierarchy for cookie matching from a given hostname.
  *
- * @param host
+ * @param host - Target hostname to analyze.
+ * @returns Array of parent and exact domain candidates.
  */
 export function cookieDomains(host: string): string[] {
   const domains = [host];
@@ -45,9 +47,11 @@ export function cookieDomains(host: string): string[] {
 }
 
 /**
+ * Default reader implementation querying local browser cookie stores.
  *
- * @param url
- * @param selection
+ * @param url - Destination URL.
+ * @param selection - Browser and profile selection options.
+ * @returns Promise resolving to matching exported cookies.
  */
 export const readCookies: CookieReader = async (url, selection) => {
   if (selection.browser === "safari" && selection.profile) {
@@ -82,10 +86,12 @@ export const readCookies: CookieReader = async (url, selection) => {
 };
 
 /**
+ * Checks whether a cookie matches a destination URL according to domain, path, secure, and expiry rules.
  *
- * @param cookie
- * @param url
- * @param now
+ * @param cookie - The exported cookie to test.
+ * @param url - Destination URL to match against.
+ * @param now - Current timestamp in milliseconds (defaults to Date.now()).
+ * @returns True if the cookie matches and is applicable for the URL.
  */
 export function cookieMatchesUrl(
   cookie: ExportedCookie,
@@ -153,10 +159,12 @@ export function cookieMatchesUrl(
 }
 
 /**
+ * Queries and filters cookies applicable to a URL, deduplicating conflicting values.
  *
- * @param url
- * @param selection
- * @param reader
+ * @param url - Destination URL.
+ * @param selection - Cookie selection criteria.
+ * @param reader - Underlying cookie reading function.
+ * @returns Filtered array of matching cookies sorted by path specificity.
  */
 export async function selectCookies(
   url: URL,
@@ -191,8 +199,10 @@ export async function selectCookies(
 }
 
 /**
+ * Builds an HTTP Cookie header string from an array of applicable cookies.
  *
- * @param cookies
+ * @param cookies - Array of cookies to serialize.
+ * @returns Formatted Cookie header value.
  */
 export function cookieHeader(cookies: ExportedCookie[]): string {
   if (cookies.length === 0) {

--- a/src/mcp/fetch.ts
+++ b/src/mcp/fetch.ts
@@ -1,0 +1,150 @@
+import {
+  cookieHeader,
+  type CookieReader,
+  type CookieSelection,
+  selectCookies,
+} from "./cookies";
+import { assertAllowedUrl, McpOperationError, type McpPolicy } from "./policy";
+
+/**
+ *
+ */
+export interface FetchInput extends CookieSelection {
+  url: string;
+  method: string;
+  headers?: Record<string, string> | undefined;
+  body?: string | undefined;
+  timeoutMs: number;
+  maxResponseBytes: number;
+}
+
+const REQUEST_HEADERS = new Set([
+  "accept",
+  "accept-language",
+  "content-type",
+  "if-none-match",
+  "if-modified-since",
+  "x-csrf-token",
+  "x-xsrf-token",
+  "x-requested-with",
+]);
+const RESPONSE_HEADERS = [
+  "content-type",
+  "content-length",
+  "etag",
+  "last-modified",
+  "retry-after",
+];
+
+async function readBody(response: Response, limit: number) {
+  if (!response.body) {
+    return { body: "", truncated: false, bytes: 0 };
+  }
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let bytes = 0;
+  let truncated = false;
+  try {
+    while (true) {
+      const result = await reader.read();
+      if (result.done) {
+        break;
+      }
+      const remaining = limit - bytes;
+      if (result.value.byteLength > remaining) {
+        chunks.push(result.value.subarray(0, remaining));
+        bytes += remaining;
+        truncated = true;
+        await reader.cancel();
+        break;
+      }
+      chunks.push(result.value);
+      bytes += result.value.byteLength;
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  return { body: Buffer.concat(chunks).toString("utf8"), truncated, bytes };
+}
+
+/**
+ *
+ * @param input
+ * @param policy
+ * @param reader
+ * @param fetchImpl
+ * @param cancellation
+ */
+export async function authenticatedFetch(
+  input: FetchInput,
+  policy: McpPolicy,
+  reader: CookieReader,
+  fetchImpl: typeof fetch = fetch,
+  cancellation?: AbortSignal,
+) {
+  const url = assertAllowedUrl(input.url, policy);
+  if (!["GET", "HEAD"].includes(input.method) && !policy.allowUnsafeMethods) {
+    throw new McpOperationError(
+      "This method requires --allow-unsafe-methods at server startup.",
+    );
+  }
+  if (input.body !== undefined && ["GET", "HEAD"].includes(input.method)) {
+    throw new McpOperationError("GET and HEAD cannot include a request body.");
+  }
+  if (input.body !== undefined && Buffer.byteLength(input.body) > 65536) {
+    throw new McpOperationError("Request body exceeds 64 KiB.");
+  }
+  const headers = new Headers();
+  for (const [name, value] of Object.entries(input.headers ?? {})) {
+    if (!REQUEST_HEADERS.has(name.toLowerCase())) {
+      throw new McpOperationError(
+        "Unsupported request header. Cookie and transport headers are managed by the server.",
+      );
+    }
+    headers.set(name, value);
+  }
+  cancellation?.throwIfAborted();
+  const cookies = await selectCookies(url, input, reader);
+  cancellation?.throwIfAborted();
+  headers.set("cookie", cookieHeader(cookies));
+  const controller = new AbortController();
+  const abort = () => controller.abort();
+  cancellation?.addEventListener("abort", abort, { once: true });
+  const timer = setTimeout(abort, input.timeoutMs);
+  try {
+    // Manual redirects are essential: even another allowed origin must get its
+    // own explicit call and freshly selected cookies. Never forward this header.
+    const response = await fetchImpl(url, {
+      method: input.method,
+      headers,
+      redirect: "manual",
+      signal: controller.signal,
+      ...(input.body !== undefined && { body: input.body }),
+    });
+    const responseHeaders: Record<string, string> = {};
+    for (const name of RESPONSE_HEADERS) {
+      const value = response.headers.get(name);
+      if (value !== null) {
+        responseHeaders[name] = value;
+      }
+    }
+    const body = await readBody(response, input.maxResponseBytes);
+    return {
+      status: response.status,
+      ok: response.ok,
+      redirect: response.status >= 300 && response.status < 400,
+      headers: responseHeaders,
+      ...body,
+      cookiesSent: cookies.length,
+    };
+  } catch {
+    throw new McpOperationError(
+      controller.signal.aborted
+        ? "Request cancelled or timed out."
+        : "Authenticated request failed.",
+    );
+  } finally {
+    clearTimeout(timer);
+    cancellation?.removeEventListener("abort", abort);
+  }
+}

--- a/src/mcp/fetch.ts
+++ b/src/mcp/fetch.ts
@@ -7,7 +7,7 @@ import {
 import { assertAllowedUrl, McpOperationError, type McpPolicy } from "./policy";
 
 /**
- *
+ * Input arguments for the authenticated HTTP fetch operation.
  */
 export interface FetchInput extends CookieSelection {
   url: string;
@@ -68,12 +68,14 @@ async function readBody(response: Response, limit: number) {
 }
 
 /**
+ * Performs an HTTP request with local cookies attached, respecting origin and method policy.
  *
- * @param input
- * @param policy
- * @param reader
- * @param fetchImpl
- * @param cancellation
+ * @param input - Request parameters and cookie selection criteria.
+ * @param policy - Security policy enforcing origin and method constraints.
+ * @param reader - Function for extracting local cookies.
+ * @param fetchImpl - Fetch implementation (defaults to global fetch).
+ * @param cancellation - Optional external cancellation signal.
+ * @returns Response object with status, headers, body, and truncation indicator.
  */
 export async function authenticatedFetch(
   input: FetchInput,

--- a/src/mcp/policy.ts
+++ b/src/mcp/policy.ts
@@ -1,0 +1,96 @@
+import { parseArgs } from "node:util";
+
+/**
+ *
+ */
+export interface McpPolicy {
+  allowedOrigins: ReadonlySet<string>;
+  allowCookieValues: boolean;
+  allowUnsafeMethods: boolean;
+}
+
+/**
+ *
+ */
+export class McpOperationError extends Error {}
+
+/**
+ *
+ * @param value
+ */
+export function parseHttpUrl(value: string): URL {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new McpOperationError("Provide an absolute HTTP or HTTPS URL.");
+  }
+  if (
+    !["http:", "https:"].includes(url.protocol) ||
+    url.username ||
+    url.password ||
+    url.hash ||
+    url.hostname.includes("*")
+  ) {
+    throw new McpOperationError(
+      "URLs must use HTTP(S), without credentials or fragments.",
+    );
+  }
+  return url;
+}
+
+/**
+ *
+ * @param value
+ * @param policy
+ */
+export function assertAllowedUrl(value: string, policy: McpPolicy): URL {
+  const url = parseHttpUrl(value);
+  if (!policy.allowedOrigins.has(url.origin)) {
+    throw new McpOperationError(
+      "Origin is not enabled. Add its exact scheme, host and port with --allow-origin at server startup.",
+    );
+  }
+  return url;
+}
+
+/**
+ *
+ * @param args
+ */
+export function parseMcpArgs(args: string[]): McpPolicy & { help: boolean } {
+  const { values } = parseArgs({
+    args,
+    strict: true,
+    allowPositionals: false,
+    options: {
+      "allow-origin": { type: "string", multiple: true },
+      "allow-cookie-values": { type: "boolean", default: false },
+      "allow-unsafe-methods": { type: "boolean", default: false },
+      help: { type: "boolean", short: "h", default: false },
+    },
+  });
+  const origins = (values["allow-origin"] ?? []).map((value) => {
+    const url = parseHttpUrl(value);
+    if (url.pathname !== "/" || url.search) {
+      throw new McpOperationError(
+        "--allow-origin accepts an origin, without a path or query.",
+      );
+    }
+    if (
+      url.protocol !== "https:" &&
+      !["localhost", "127.0.0.1", "[::1]"].includes(url.hostname)
+    ) {
+      throw new McpOperationError(
+        "Use HTTPS origins; HTTP is supported only for explicit loopback origins.",
+      );
+    }
+    return url.origin;
+  });
+  return {
+    allowedOrigins: new Set(origins),
+    allowCookieValues: values["allow-cookie-values"],
+    allowUnsafeMethods: values["allow-unsafe-methods"],
+    help: values.help,
+  };
+}

--- a/src/mcp/policy.ts
+++ b/src/mcp/policy.ts
@@ -1,7 +1,7 @@
 import { parseArgs } from "node:util";
 
 /**
- *
+ * Security and access control policy configuration for the MCP server.
  */
 export interface McpPolicy {
   allowedOrigins: ReadonlySet<string>;
@@ -10,13 +10,16 @@ export interface McpPolicy {
 }
 
 /**
- *
+ * Error raised when an MCP tool operation or policy validation fails.
  */
 export class McpOperationError extends Error {}
 
 /**
+ * Parses and validates an absolute HTTP or HTTPS URL string.
  *
- * @param value
+ * @param value - The raw URL string to validate.
+ * @returns The parsed URL instance.
+ * @throws McpOperationError if URL is invalid, non-HTTP(S), or contains credentials/fragments.
  */
 export function parseHttpUrl(value: string): URL {
   let url: URL;
@@ -40,9 +43,12 @@ export function parseHttpUrl(value: string): URL {
 }
 
 /**
+ * Validates that the provided URL belongs to an allowed origin per the given policy.
  *
- * @param value
- * @param policy
+ * @param value - The raw URL string to check.
+ * @param policy - The active MCP policy containing allowed origins.
+ * @returns The parsed and validated URL instance.
+ * @throws McpOperationError if the URL origin is not in the allowed set.
  */
 export function assertAllowedUrl(value: string, policy: McpPolicy): URL {
   const url = parseHttpUrl(value);
@@ -55,8 +61,10 @@ export function assertAllowedUrl(value: string, policy: McpPolicy): URL {
 }
 
 /**
+ * Parses command-line arguments for the MCP server subcommand.
  *
- * @param args
+ * @param args - CLI arguments array passed after 'mcp'.
+ * @returns Parsed McpPolicy and help flag.
  */
 export function parseMcpArgs(args: string[]): McpPolicy & { help: boolean } {
   const { values } = parseArgs({

--- a/src/mcp/profiles.ts
+++ b/src/mcp/profiles.ts
@@ -1,0 +1,42 @@
+import { join } from "node:path";
+
+import { FIREFOX_DATA_DIRS } from "../core/browsers/BrowserAvailability";
+import { getChromiumProfiles } from "../core/browsers/chromium/getChromiumProfiles";
+import { parseFirefoxProfilesIni } from "../core/browsers/firefox/FirefoxCookieQueryStrategy";
+import { fileExists } from "../core/browsers/runtime/FileSystemAdapter";
+
+/**
+ *
+ * @param browser
+ */
+export function listProfiles(browser?: string) {
+  const profiles: { browser: string; name: string; directory: string }[] = [];
+  if (!browser || (browser !== "firefox" && browser !== "safari")) {
+    profiles.push(
+      ...getChromiumProfiles(browser).map((profile) => ({
+        browser: profile.browser,
+        name: profile.name,
+        directory: profile.directory,
+      })),
+    );
+  }
+  if (!browser || browser === "firefox") {
+    for (const dir of FIREFOX_DATA_DIRS[process.platform] ?? []) {
+      const ini = join(dir, "profiles.ini");
+      if (!fileExists(ini)) {
+        continue;
+      }
+      profiles.push(
+        ...parseFirefoxProfilesIni(ini).map((profile) => ({
+          browser: "firefox",
+          name: profile.name,
+          directory: profile.path,
+        })),
+      );
+    }
+  }
+  return {
+    profiles,
+    note: "Safari uses its default cookie store and does not support named profiles.",
+  };
+}

--- a/src/mcp/profiles.ts
+++ b/src/mcp/profiles.ts
@@ -6,8 +6,10 @@ import { parseFirefoxProfilesIni } from "../core/browsers/firefox/FirefoxCookieQ
 import { fileExists } from "../core/browsers/runtime/FileSystemAdapter";
 
 /**
+ * Lists available browser profiles for a given browser or across all supported browsers.
  *
- * @param browser
+ * @param browser - Optional browser name to filter profiles.
+ * @returns Array of browser profile descriptors with browser, profile name, and directory path.
  */
 export function listProfiles(browser?: string) {
   const profiles: { browser: string; name: string; directory: string }[] = [];

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,0 +1,215 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+
+import { version } from "../../package.json";
+import { resetGlobalConnectionManager } from "../core/browsers/sql/DatabaseConnectionManager";
+
+import { type CookieReader, readCookies, selectCookies } from "./cookies";
+import { authenticatedFetch } from "./fetch";
+import { assertAllowedUrl, McpOperationError, type McpPolicy } from "./policy";
+import { listProfiles } from "./profiles";
+
+const browser = z.enum([
+  "chrome",
+  "edge",
+  "arc",
+  "brave",
+  "opera",
+  "opera-gx",
+  "vivaldi",
+  "firefox",
+  "safari",
+]);
+const selection = {
+  url: z
+    .string()
+    .max(8192)
+    .describe("Exact destination URL, including path, on an enabled origin."),
+  browser,
+  profile: z.string().min(1).max(256).optional(),
+  container: z
+    .union([z.string().min(1).max(256), z.number().int().nonnegative()])
+    .optional()
+    .describe(
+      "Firefox container name or ID; defaults to the non-container store.",
+    ),
+  name: z
+    .string()
+    .min(1)
+    .max(256)
+    .optional()
+    .describe("Exact cookie name; omit to select all applicable cookies."),
+};
+
+/**
+ *
+ */
+export interface McpDependencies {
+  readCookies: CookieReader;
+  listProfiles: typeof listProfiles;
+  fetch: typeof fetch;
+}
+
+function result(output: Record<string, unknown>) {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(output) }],
+    structuredContent: output,
+  };
+}
+
+async function execute(operation: () => Promise<Record<string, unknown>>) {
+  try {
+    return result(await operation());
+  } catch (error) {
+    return {
+      isError: true,
+      content: [
+        {
+          type: "text" as const,
+          text:
+            error instanceof McpOperationError
+              ? error.message
+              : "Operation failed. Check local browser access and server configuration.",
+        },
+      ],
+    };
+  }
+}
+
+/**
+ *
+ * @param policy
+ * @param overrides
+ */
+export function createMcpServer(
+  policy: McpPolicy,
+  overrides: Partial<McpDependencies> = {},
+): McpServer {
+  const deps: McpDependencies = {
+    readCookies,
+    listProfiles,
+    fetch,
+    ...overrides,
+  };
+  const server = new McpServer({ name: "get-cookie", version });
+  server.registerTool(
+    "list_profiles",
+    {
+      description: "List local browser profiles available for cookie access.",
+      inputSchema: { browser: browser.optional() },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        openWorldHint: false,
+      },
+    },
+    async ({ browser }) => execute(async () => deps.listProfiles(browser)),
+  );
+
+  server.registerTool(
+    "query_cookies",
+    {
+      description:
+        "Read locally stored cookies applicable to an enabled URL. Values are omitted unless requested and enabled at startup. Empty results can also indicate inaccessible stores. Partitioned cookies are excluded.",
+      inputSchema: {
+        ...selection,
+        includeValues: z.boolean().default(false),
+        limit: z.number().int().min(1).max(200).default(50),
+      },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        openWorldHint: false,
+      },
+    },
+    async (input) =>
+      execute(async () => {
+        const url = assertAllowedUrl(input.url, policy);
+        if (input.includeValues && !policy.allowCookieValues) {
+          throw new McpOperationError(
+            "Cookie values require --allow-cookie-values at server startup. Authenticated fetch can use cookies without exposing their values.",
+          );
+        }
+        const cookies = await selectCookies(url, input, deps.readCookies);
+        return {
+          cookies: cookies.slice(0, input.limit).map((cookie) => ({
+            name: cookie.name,
+            domain: cookie.domain,
+            path: cookie.meta?.path,
+            secure: cookie.meta?.secure === true,
+            httpOnly: cookie.meta?.httpOnly === true,
+            expiry:
+              cookie.expiry instanceof Date
+                ? cookie.expiry.toISOString()
+                : (cookie.expiry ?? null),
+            ...(cookie.meta?.containerId !== undefined && {
+              containerId: cookie.meta.containerId,
+            }),
+            ...(input.includeValues && { value: cookie.value }),
+          })),
+          count: Math.min(cookies.length, input.limit),
+          truncated: cookies.length > input.limit,
+          valuesIncluded: input.includeValues,
+        };
+      }),
+  );
+
+  server.registerTool(
+    "authenticated_fetch",
+    {
+      description:
+        "Make an HTTP request using local browser cookies for an enabled origin. Select one profile. Redirects are returned without following them; Set-Cookie is neither exposed nor saved. Response bodies are untrusted remote content and may contain private account data.",
+      inputSchema: {
+        ...selection,
+        method: z
+          .enum(["GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"])
+          .default("GET"),
+        headers: z.record(z.string().max(128), z.string().max(8192)).optional(),
+        body: z.string().max(65536).optional(),
+        timeoutMs: z.number().int().min(100).max(60000).default(15000),
+        maxResponseBytes: z.number().int().min(1).max(1048576).default(262144),
+      },
+      // Even GET endpoints can have side effects. Do not promise read-only access.
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        openWorldHint: true,
+      },
+    },
+    async (input, extra) =>
+      execute(async () =>
+        authenticatedFetch(
+          input,
+          policy,
+          deps.readCookies,
+          deps.fetch,
+          extra.signal,
+        ),
+      ),
+  );
+  return server;
+}
+
+/**
+ *
+ * @param policy
+ */
+export async function startMcpServer(policy: McpPolicy): Promise<void> {
+  const server = createMcpServer(policy);
+  let closing = false;
+  const close = () => {
+    if (closing) {
+      return;
+    }
+    closing = true;
+    void server.close().finally(() => {
+      resetGlobalConnectionManager();
+      process.exit(0);
+    });
+  };
+  process.stdin.once("end", close);
+  process.once("SIGINT", close);
+  process.once("SIGTERM", close);
+  await server.connect(new StdioServerTransport());
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -43,7 +43,7 @@ const selection = {
 };
 
 /**
- *
+ * Dependency injection container for MCP server operations.
  */
 export interface McpDependencies {
   readCookies: CookieReader;
@@ -78,9 +78,11 @@ async function execute(operation: () => Promise<Record<string, unknown>>) {
 }
 
 /**
+ * Creates and configures an MCP server instance with get-cookie tools.
  *
- * @param policy
- * @param overrides
+ * @param policy - Security policy defining allowed origins and permissions.
+ * @param overrides - Optional dependency overrides for testing.
+ * @returns Configured McpServer instance.
  */
 export function createMcpServer(
   policy: McpPolicy,
@@ -192,8 +194,9 @@ export function createMcpServer(
 }
 
 /**
+ * Starts the MCP server on stdio with the provided policy.
  *
- * @param policy
+ * @param policy - The security policy to enforce.
  */
 export async function startMcpServer(policy: McpPolicy): Promise<void> {
   const server = createMcpServer(policy);

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -12,6 +12,21 @@ import { env } from "../config";
  * - fatal: Critical errors that prevent the app from continuing
  */
 const consola = createConsola({
+  ...(process.argv[2] === "mcp" && {
+    reporters: [
+      {
+        log: (log: { type: string }) => {
+          // Browser diagnostics can contain cookie values. Keep protocol stdout and
+          // credential-bearing debug payloads out of MCP client logs.
+          if (log.type === "error" || log.type === "warn") {
+            process.stderr.write(
+              `get-cookie: browser ${log.type}; diagnostic details suppressed in MCP mode.\n`,
+            );
+          }
+        },
+      },
+    ],
+  }),
   formatOptions: {
     showLogLevel: false,
     colors: true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,11 @@
 {
-  "include": ["src/**/*", "scripts/**/*", "*.ts", "examples/**/*"],
+  "include": [
+    "src/**/*",
+    "scripts/**/*",
+    "*.ts",
+    "examples/**/*",
+    "package.json"
+  ],
   "compilerOptions": {
     "moduleResolution": "node",
     "target": "es2020",


### PR DESCRIPTION
## Overview & Motivation

Adds Model Context Protocol (MCP) server support to `get-cookie`.
This enables AI assistants, agent environments, and IDE tooling (e.g. Claude Desktop, Cursor, Antigravity) to securely interact with local browser cookies and issue authenticated HTTP requests against explicit user-approved origins.

Closes #591.
Refs #592, #593, #594.


## Problem & Background

Previously, utilizing browser cookies with LLM agent frameworks required manual cookie extraction or exporting plain-text credentials into chat contexts:
- Cookie secrets could inadvertently leak into model contexts, history, or telemetry logs.
- Browser diagnostic logs could expose sensitive session tokens.
- Chromium and Safari query paths decode cookie values for formatted terminal display, which could mutate raw byte values needed for standard HTTP `Cookie` headers.
- No standard protocol interface existed to discover local profiles, query specific host cookies, or execute authenticated requests on behalf of the user within defined security boundaries.

## Changes & Solution

1. **MCP Server Protocol Implementation** (`src/mcp/`):
   - Integrates `@modelcontextprotocol/sdk` via standard I/O (`StdioServerTransport`).
   - Exposes three core tools:
     - `list_profiles`: Discovers local browser profiles for Chromium-based browsers and Firefox.
     - `query_cookies`: Queries locally stored cookies matching a destination URL. Values are omitted by default unless `--allow-cookie-values` is specified at server startup. Excludes partitioned cookies.
     - `authenticated_fetch`: Executes HTTP requests with browser cookies attached in memory, returning response data without exposing cookie credentials to the LLM.
   - Enforces strict security policies via CLI flags:
     - `--allow-origin <origin>` (required for request/cookie access; HTTP only allowed on loopback).
     - `--allow-cookie-values` (explicit opt-in to return cookie values in tool responses).
     - `--allow-unsafe-methods` (required for non-safe HTTP methods like POST/PUT/DELETE).

2. **Raw Cookie Preservation via Query Context** (`src/core/cookies/CookieQueryContext.ts`):
   - Implements `AsyncLocalStorage`-based context (`withRawCookieValues()`, `usesRawCookieValues()`) to preserve exact cookie bytes during MCP execution without breaking existing terminal display queries.
   - Enhanced `BaseChromiumCookieQueryStrategy`, `FirefoxCookieQueryStrategy`, and `SafariCookieQueryStrategy` to preserve raw cookie values and request metadata (`path`, `secure`, `httpOnly`, `hostOnly`, `partitioned`).

3. **CLI Subcommand & Logging Safeguards** (`src/cli/cli.ts`, `src/utils/logger.ts`):
   - Added `get-cookie mcp` command.
   - Suppresses diagnostic details in MCP mode to keep stdout/stderr clean and prevent credential leakage in MCP client log collectors.

4. **Dependencies**:
   - Added `@modelcontextprotocol/sdk` and `tldts`.

## Verification

- Full test suite passed: 87/87 test suites, 693 tests passed.
- Added comprehensive unit tests:
  - `src/mcp/__tests__/cookies.test.ts`
  - `src/mcp/__tests__/fetch.test.ts`
  - `src/core/browsers/chrome/__tests__/decrypt.raw.test.ts`
- Passed full validation (`pnpm run validate`):
  - TypeScript type check (`tsc --noEmit --skipLibCheck`)
  - Biome linting and formatting (`biome check --diagnostic-level=error .`)
  - VitePress documentation links (`./scripts/check-vitepress-links.sh`)
- Verified build succeeds (`pnpm run build`).
