### PR TITLE
fix(cookies): finish raw values and metadata for MCP requests

### DIFF
--- a/src/cli/CookieFormatter.ts
+++ b/src/cli/CookieFormatter.ts
@@ -1,6 +1,8 @@
+import { groupBy } from "lodash-es";
+
 import { renderCookies } from "@core/cookies/renderCookies";
 import logger from "@utils/logger";
-import { groupBy } from "lodash-es";
+
 import type { ExportedCookie } from "../types/schemas";
 
 /**
@@ -35,7 +37,6 @@ export function validateOutputFormat(options: CookieFormatOptions): void {
 
 /**
  * Formats an array of exported cookies into a string according to output options.
- *
  * @param cookies - Array of exported cookies
  * @param options - Formatting options / CLI arguments
  * @returns Formatted output string

--- a/src/cli/services/CookieStrategyFactory.ts
+++ b/src/cli/services/CookieStrategyFactory.ts
@@ -35,6 +35,7 @@ export const CookieStrategyFactory = {
    * @param browser - The browser to create a strategy for
    * @param storePath - Optional path to a cookie store file
    * @param profile - Optional Chrome profile name
+   * @param container
    * @returns A cookie query strategy for the specified browser
    */
   createStrategy(

--- a/src/core/browsers/StrategyFactory.ts
+++ b/src/core/browsers/StrategyFactory.ts
@@ -12,7 +12,6 @@ import {
   isValidBrowserType,
 } from "./BrowserDetector";
 import { ChromeCookieQueryStrategy } from "./chrome/ChromeCookieQueryStrategy";
-import type { ChromiumBrowser } from "./chrome/ChromiumBrowsers";
 import { ChromiumCookieQueryStrategy } from "./chromium/ChromiumCookieQueryStrategy";
 import { CompositeCookieQueryStrategy } from "./CompositeCookieQueryStrategy";
 import { FirefoxCookieQueryStrategy } from "./firefox/FirefoxCookieQueryStrategy";
@@ -51,7 +50,6 @@ const CHROMIUM_BROWSERS: Set<string> = new Set([
 
 /**
  * Creates a strategy for the specified browser
- *
  * @param browser - The browser to create a strategy for
  * @param profile - Optional profile name to target (supported by Chromium-based browsers)
  * @param container - Optional Firefox container name, ID, or "none"
@@ -83,7 +81,7 @@ export function createBrowserStrategy(
   }
 
   if (CHROMIUM_BROWSERS.has(browser)) {
-    return new ChromiumCookieQueryStrategy(browser as ChromiumBrowser, profile);
+    return new ChromiumCookieQueryStrategy(browser, profile);
   }
 
   return new ChromiumCookieQueryStrategy("chrome", profile);

--- a/src/core/browsers/chrome/__tests__/decrypt.raw.test.ts
+++ b/src/core/browsers/chrome/__tests__/decrypt.raw.test.ts
@@ -8,22 +8,62 @@ jest.mock("@utils/platformUtils", () => ({
   isWindows: () => false,
 }));
 
-it("preserves full authentication values without changing concurrent display queries", async () => {
-  const value = "prefix-12345678-1234-1234-1234-123456789abc-suffix";
+function encryptAes128Cbc(value: string, password = "password"): Buffer {
   const cipher = createCipheriv(
     "aes-128-cbc",
-    pbkdf2Sync("password", "saltysalt", 1003, 16, "sha1"),
+    pbkdf2Sync(password, "saltysalt", 1003, 16, "sha1"),
     Buffer.alloc(16, " "),
   );
-  const encrypted = Buffer.concat([
+  return Buffer.concat([
     Buffer.from("v10"),
     cipher.update(value),
     cipher.final(),
   ]);
-  const [raw, display] = await Promise.all([
-    withRawCookieValues(async () => decrypt(encrypted, "password")),
-    decrypt(encrypted, "password"),
-  ]);
-  expect(raw).toBe(value);
-  expect(display).toBe("12345678-1234-1234-1234-123456789abc");
+}
+
+describe("decrypt - raw cookie values vs display mode", () => {
+  it("preserves full authentication values without changing concurrent display queries", async () => {
+    const value = "prefix-12345678-1234-1234-1234-123456789abc-suffix";
+    const encrypted = encryptAes128Cbc(value);
+
+    const [raw, display] = await Promise.all([
+      withRawCookieValues(async () => decrypt(encrypted, "password")),
+      decrypt(encrypted, "password"),
+    ]);
+
+    expect(raw).toBe(value);
+    expect(display).toBe("12345678-1234-1234-1234-123456789abc");
+  });
+
+  it("preserves percent-encoded values and JWTs unchanged in raw mode", async () => {
+    const percentEncoded = "user%20token%3Dsecret%26scope%3Dadmin%2Bwrite";
+    const jwt =
+      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP8p4w62I";
+
+    const encPercent = encryptAes128Cbc(percentEncoded);
+    const encJwt = encryptAes128Cbc(jwt);
+
+    const [rawPercent, rawJwt] = await Promise.all([
+      withRawCookieValues(async () => decrypt(encPercent, "password")),
+      withRawCookieValues(async () => decrypt(encJwt, "password")),
+    ]);
+
+    expect(rawPercent).toBe(percentEncoded);
+    expect(rawJwt).toBe(jwt);
+  });
+
+  it("handles empty and malformed encrypted values in raw mode", async () => {
+    // On macOS non-versioned buffers are treated as legacy plaintext
+    const plaintext = await withRawCookieValues(async () =>
+      decrypt(Buffer.from("legacy-plaintext"), "password"),
+    );
+    expect(plaintext).toBe("legacy-plaintext");
+
+    // v10-prefixed buffer with invalid length throws
+    await expect(
+      withRawCookieValues(async () =>
+        decrypt(Buffer.from("v10invalidlength"), "password"),
+      ),
+    ).rejects.toThrow("Encrypted data length is not a multiple of 16");
+  });
 });

--- a/src/core/browsers/chromium/BaseChromiumCookieQueryStrategy.ts
+++ b/src/core/browsers/chromium/BaseChromiumCookieQueryStrategy.ts
@@ -666,15 +666,21 @@ export abstract class BaseChromiumCookieQueryStrategy extends BaseCookieQueryStr
         error: this.getErrorMessage(error),
       });
 
-      return createExportedCookie(
+      const failed = createExportedCookie(
         cookie.domain,
         cookie.name,
-        cookie.value.toString("utf-8"),
+        Buffer.isBuffer(cookie.value)
+          ? cookie.value.toString("utf-8")
+          : String(cookie.value),
         cookie.expiry,
         context.file,
         context.browser,
         false,
       );
+      if (cookie.requestMeta && failed.meta) {
+        Object.assign(failed.meta, cookie.requestMeta);
+      }
+      return failed;
     }
   }
 }

--- a/src/core/browsers/chromium/__tests__/BaseChromiumCookieQueryStrategy.raw.test.ts
+++ b/src/core/browsers/chromium/__tests__/BaseChromiumCookieQueryStrategy.raw.test.ts
@@ -1,0 +1,345 @@
+import { createCipheriv, pbkdf2Sync } from "node:crypto";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import Database from "better-sqlite3";
+
+import { withRawCookieValues } from "../../../cookies/CookieQueryContext";
+import { BaseChromiumCookieQueryStrategy } from "../BaseChromiumCookieQueryStrategy";
+
+jest.mock("../../chrome/getChromiumPassword", () => ({
+  getChromiumPassword: jest.fn().mockResolvedValue("password"),
+}));
+
+function encryptAes128Cbc(
+  value: string,
+  password = "password",
+  withHashPrefix = true,
+): Buffer {
+  const cipher = createCipheriv(
+    "aes-128-cbc",
+    pbkdf2Sync(password, "saltysalt", 1003, 16, "sha1"),
+    Buffer.alloc(16, " "),
+  );
+  const payload = withHashPrefix
+    ? Buffer.concat([Buffer.alloc(32, "a"), Buffer.from(value, "utf8")])
+    : Buffer.from(value, "utf8");
+  return Buffer.concat([
+    Buffer.from("v10"),
+    cipher.update(payload),
+    cipher.final(),
+  ]);
+}
+
+class TestChromiumStrategy extends BaseChromiumCookieQueryStrategy {
+  public constructor(private readonly files: string[]) {
+    super("TestChromiumStrategy", "Chrome", "chrome");
+  }
+
+  protected override getCookieFilePaths(): string[] {
+    return this.files;
+  }
+
+  protected override getCookieFiles(): string[] {
+    return this.files;
+  }
+
+  protected override isPlatformSupported(): boolean {
+    return true;
+  }
+}
+
+describe("BaseChromiumCookieQueryStrategy — raw values & metadata", () => {
+  let tempDir: string;
+  let modernDbPath: string;
+  let legacyDbPath: string;
+
+  const rawAuthToken = "prefix-12345678-1234-1234-1234-123456789abc-suffix";
+  const jwt =
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP8p4w62I";
+  const percentEncoded = "token%20value%3D123%26role%3Dadmin";
+  const futureExpiry = Math.floor(Date.now() / 1000) + 86400;
+  // Chrome timestamp: microseconds since 1601-01-01 (approx 11644473600 seconds offset)
+  const chromeExpiry = (futureExpiry + 11644473600) * 1000000;
+
+  beforeAll(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "chromium-raw-test-"));
+    modernDbPath = join(tempDir, "modern-cookies.sqlite");
+    legacyDbPath = join(tempDir, "legacy-cookies.sqlite");
+
+    // 1. Create modern database with top_frame_site_key
+    const modernDb = new Database(modernDbPath);
+    modernDb.exec(`
+      CREATE TABLE meta (key TEXT NOT NULL UNIQUE, value TEXT);
+      INSERT INTO meta VALUES ('version', '24');
+      CREATE TABLE cookies (
+        creation_utc INTEGER NOT NULL,
+        host_key TEXT NOT NULL,
+        top_frame_site_key TEXT NOT NULL,
+        name TEXT NOT NULL,
+        value TEXT NOT NULL,
+        encrypted_value BLOB NOT NULL,
+        path TEXT NOT NULL,
+        expires_utc INTEGER NOT NULL,
+        is_secure INTEGER NOT NULL,
+        is_httponly INTEGER NOT NULL,
+        last_access_utc INTEGER NOT NULL,
+        has_expires INTEGER NOT NULL,
+        is_persistent INTEGER NOT NULL,
+        priority INTEGER NOT NULL,
+        samesite INTEGER NOT NULL,
+        source_scheme INTEGER NOT NULL,
+        source_port INTEGER NOT NULL,
+        is_same_party INTEGER NOT NULL,
+        last_update_utc INTEGER NOT NULL
+      );
+    `);
+
+    const insertModern = modernDb.prepare(`
+      INSERT INTO cookies (
+        creation_utc, host_key, top_frame_site_key, name, value,
+        encrypted_value, path, expires_utc, is_secure, is_httponly,
+        last_access_utc, has_expires, is_persistent, priority,
+        samesite, source_scheme, source_port, is_same_party, last_update_utc
+      ) VALUES (
+        0, ?, ?, ?, ?,
+        ?, ?, ?, ?, ?,
+        0, 1, 1, 1,
+        0, 1, 443, 0, 0
+      )
+    `);
+
+    // Row 1: Encrypted raw auth token with UUID substring and domain wildcard
+    insertModern.run(
+      ".example.com",
+      "",
+      "auth_token",
+      "",
+      encryptAes128Cbc(rawAuthToken),
+      "/api",
+      chromeExpiry,
+      1,
+      1,
+    );
+
+    // Row 2: Encrypted JWT
+    insertModern.run(
+      "example.com",
+      "",
+      "jwt_token",
+      "",
+      encryptAes128Cbc(jwt),
+      "/",
+      chromeExpiry,
+      1,
+      0,
+    );
+
+    // Row 3: Plaintext fallback when encrypted_value is empty
+    insertModern.run(
+      "example.com",
+      "",
+      "plain_token",
+      percentEncoded,
+      Buffer.alloc(0),
+      "/secure",
+      chromeExpiry,
+      0,
+      1,
+    );
+
+    // Row 4: Partitioned cookie with top_frame_site_key
+    insertModern.run(
+      ".example.com",
+      "https://partitioned.com",
+      "partition_cookie",
+      "val",
+      Buffer.alloc(0),
+      "/",
+      chromeExpiry,
+      0,
+      0,
+    );
+
+    // Row 5: Decryption failure (corrupted encrypted payload)
+    insertModern.run(
+      "example.com",
+      "",
+      "corrupt_cookie",
+      "",
+      Buffer.from("v10badlength"),
+      "/failed",
+      chromeExpiry,
+      1,
+      1,
+    );
+
+    modernDb.close();
+
+    // 2. Create legacy database WITHOUT top_frame_site_key
+    const legacyDb = new Database(legacyDbPath);
+    legacyDb.exec(`
+      CREATE TABLE cookies (
+        creation_utc INTEGER NOT NULL,
+        host_key TEXT NOT NULL,
+        name TEXT NOT NULL,
+        value TEXT NOT NULL,
+        encrypted_value BLOB NOT NULL,
+        path TEXT NOT NULL,
+        expires_utc INTEGER NOT NULL,
+        is_secure INTEGER NOT NULL,
+        is_httponly INTEGER NOT NULL,
+        last_access_utc INTEGER NOT NULL,
+        has_expires INTEGER NOT NULL,
+        is_persistent INTEGER NOT NULL,
+        priority INTEGER NOT NULL,
+        samesite INTEGER NOT NULL,
+        source_scheme INTEGER NOT NULL,
+        source_port INTEGER NOT NULL,
+        is_same_party INTEGER NOT NULL,
+        last_update_utc INTEGER NOT NULL
+      );
+    `);
+
+    const insertLegacy = legacyDb.prepare(`
+      INSERT INTO cookies (
+        creation_utc, host_key, name, value,
+        encrypted_value, path, expires_utc, is_secure, is_httponly,
+        last_access_utc, has_expires, is_persistent, priority,
+        samesite, source_scheme, source_port, is_same_party, last_update_utc
+      ) VALUES (
+        0, ?, ?, ?,
+        ?, ?, ?, ?, ?,
+        0, 1, 1, 1,
+        0, 1, 443, 0, 0
+      )
+    `);
+
+    insertLegacy.run(
+      "example.com",
+      "legacy_token",
+      "legacy_plain",
+      Buffer.alloc(0),
+      "/legacy",
+      chromeExpiry,
+      1,
+      1,
+    );
+
+    legacyDb.close();
+  });
+
+  afterAll(() => {
+    try {
+      rmSync(tempDir, { recursive: true, force: true });
+    } catch {
+      // Ignore cleanup error
+    }
+  });
+
+  it("extracts raw values with full metadata under withRawCookieValues()", async () => {
+    const strategy = new TestChromiumStrategy([modernDbPath]);
+
+    const cookies = await withRawCookieValues(async () =>
+      strategy.queryCookies("%", "%", modernDbPath),
+    );
+
+    const tokenCookie = cookies.find((c) => c.name === "auth_token");
+    expect(tokenCookie).toBeDefined();
+    expect(tokenCookie?.value).toBe(rawAuthToken);
+    expect(tokenCookie?.meta).toMatchObject({
+      file: modernDbPath,
+      browser: "Chrome",
+      decrypted: true,
+      secure: true,
+      httpOnly: true,
+      path: "/api",
+      hostOnly: false,
+      partitioned: false,
+    });
+
+    const jwtCookie = cookies.find((c) => c.name === "jwt_token");
+    expect(jwtCookie).toBeDefined();
+    expect(jwtCookie?.value).toBe(jwt);
+    expect(jwtCookie?.meta).toMatchObject({
+      decrypted: true,
+      secure: true,
+      httpOnly: false,
+      path: "/",
+      hostOnly: true,
+      partitioned: false,
+    });
+
+    const plainCookie = cookies.find((c) => c.name === "plain_token");
+    expect(plainCookie).toBeDefined();
+    expect(plainCookie?.value).toBe(percentEncoded);
+    expect(plainCookie?.meta).toMatchObject({
+      decrypted: true,
+      secure: false,
+      httpOnly: true,
+      path: "/secure",
+      hostOnly: true,
+      partitioned: false,
+    });
+
+    const partitionedCookie = cookies.find(
+      (c) => c.name === "partition_cookie",
+    );
+    expect(partitionedCookie).toBeDefined();
+    expect(partitionedCookie?.meta?.partitioned).toBe(true);
+
+    const corruptCookie = cookies.find((c) => c.name === "corrupt_cookie");
+    expect(corruptCookie).toBeDefined();
+    expect(corruptCookie?.meta?.decrypted).toBe(false);
+    expect(corruptCookie?.meta?.path).toBe("/failed");
+  });
+
+  it("preserves display-mode extraction without request metadata and isolates concurrent runs", async () => {
+    const strategy = new TestChromiumStrategy([modernDbPath]);
+
+    const [rawCookies, displayCookies] = await Promise.all([
+      withRawCookieValues(async () =>
+        strategy.queryCookies("%", "%", modernDbPath),
+      ),
+      strategy.queryCookies("%", "%", modernDbPath),
+    ]);
+
+    const rawToken = rawCookies.find((c) => c.name === "auth_token");
+    const displayToken = displayCookies.find((c) => c.name === "auth_token");
+
+    expect(rawToken?.value).toBe(rawAuthToken);
+    expect(rawToken?.meta?.path).toBe("/api");
+    expect(rawToken?.meta?.secure).toBe(true);
+
+    // Display mode extracts UUID substring from value
+    expect(displayToken?.value).toBe("12345678-1234-1234-1234-123456789abc");
+    expect(displayToken?.meta?.path).toBeUndefined();
+    expect(displayToken?.meta?.secure).toBeUndefined();
+    expect(displayToken?.meta?.hostOnly).toBeUndefined();
+  });
+
+  it("handles legacy Chromium schemas without top_frame_site_key gracefully", async () => {
+    const strategy = new TestChromiumStrategy([legacyDbPath]);
+
+    const cookies = await withRawCookieValues(async () =>
+      strategy.queryCookies("%", "%", legacyDbPath),
+    );
+
+    expect(cookies).toHaveLength(1);
+    expect(cookies[0]).toMatchObject({
+      name: "legacy_token",
+      value: "legacy_plain",
+      meta: {
+        file: legacyDbPath,
+        browser: "Chrome",
+        decrypted: true,
+        secure: true,
+        httpOnly: true,
+        path: "/legacy",
+        hostOnly: true,
+        partitioned: false,
+      },
+    });
+  });
+});

--- a/src/core/browsers/chromium/__tests__/getChromiumProfiles.test.ts
+++ b/src/core/browsers/chromium/__tests__/getChromiumProfiles.test.ts
@@ -1,5 +1,5 @@
-import { getChromiumProfiles } from "../getChromiumProfiles";
 import { setFileSystemAdapter } from "../../runtime/FileSystemAdapter";
+import { getChromiumProfiles } from "../getChromiumProfiles";
 
 describe("getChromiumProfiles", () => {
   beforeEach(() => {

--- a/src/core/browsers/chromium/getChromiumProfiles.ts
+++ b/src/core/browsers/chromium/getChromiumProfiles.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+
 import { CHROMIUM_DATA_DIRS } from "../BrowserAvailability";
 import { fileExists, readTextFile } from "../runtime/FileSystemAdapter";
 
@@ -41,7 +42,6 @@ interface LocalStateProfileInfo {
 /**
  * Helper to discover profiles in a specific User Data directory for a browser name.
  * Reads the `Local State` JSON file's `profile.info_cache` object.
- *
  * @param browserName - Name of the browser (e.g. "chrome", "edge")
  * @param dataDir - Absolute path to the browser's User Data directory
  * @returns Array of discovered ChromiumProfile entries
@@ -88,9 +88,8 @@ function discoverProfilesInDir(
 
 /**
  * Enumerates installed profiles for a Chromium-based browser (or all Chromium-based browsers).
- *
  * @param targetBrowser - Optional browser name (e.g. "chrome", "edge", "brave") or path to User Data dir.
- *                        If omitted, enumerates profiles across all supported Chromium browsers on the current OS.
+ * If omitted, enumerates profiles across all supported Chromium browsers on the current OS.
  * @returns Array of discovered ChromiumProfile entries
  */
 export function getChromiumProfiles(targetBrowser?: string): ChromiumProfile[] {

--- a/src/core/browsers/firefox/FirefoxContainers.ts
+++ b/src/core/browsers/firefox/FirefoxContainers.ts
@@ -2,6 +2,9 @@ import { dirname, join } from "node:path";
 
 import { fileExists, readTextFile } from "../runtime/FileSystemAdapter";
 
+/**
+ *
+ */
 export interface FirefoxContainer {
   userContextId: number;
   name: string;
@@ -9,6 +12,9 @@ export interface FirefoxContainer {
   color?: string;
 }
 
+/**
+ *
+ */
 export interface FirefoxContainersConfig {
   containers?: FirefoxContainer[];
   [key: string]: unknown;

--- a/src/core/browsers/firefox/FirefoxContainers.ts
+++ b/src/core/browsers/firefox/FirefoxContainers.ts
@@ -3,7 +3,7 @@ import { dirname, join } from "node:path";
 import { fileExists, readTextFile } from "../runtime/FileSystemAdapter";
 
 /**
- *
+ * Represents a Firefox Multi-Account Container definition.
  */
 export interface FirefoxContainer {
   userContextId: number;
@@ -13,7 +13,7 @@ export interface FirefoxContainer {
 }
 
 /**
- *
+ * Schema for Firefox containers.json configuration file.
  */
 export interface FirefoxContainersConfig {
   containers?: FirefoxContainer[];

--- a/src/core/browsers/firefox/__tests__/FirefoxContainers.test.ts
+++ b/src/core/browsers/firefox/__tests__/FirefoxContainers.test.ts
@@ -1,9 +1,9 @@
+import * as fileSystemAdapter from "../../runtime/FileSystemAdapter";
 import {
   extractUserContextId,
   parseFirefoxContainersJson,
   resolveFirefoxContainer,
 } from "../FirefoxContainers";
-import * as fileSystemAdapter from "../../runtime/FileSystemAdapter";
 
 jest.mock("../../runtime/FileSystemAdapter");
 

--- a/src/core/browsers/firefox/__tests__/FirefoxCookieQueryStrategy.raw.test.ts
+++ b/src/core/browsers/firefox/__tests__/FirefoxCookieQueryStrategy.raw.test.ts
@@ -1,0 +1,342 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import Database from "better-sqlite3";
+
+import { withRawCookieValues } from "../../../cookies/CookieQueryContext";
+import { FirefoxCookieQueryStrategy } from "../FirefoxCookieQueryStrategy";
+
+describe("FirefoxCookieQueryStrategy — raw values & metadata", () => {
+  let tempDir: string;
+  let schema15Dir: string;
+  let schema16Dir: string;
+  let schema15DbPath: string;
+  let schema16DbPath: string;
+
+  const rawAuthToken = "prefix-12345678-1234-1234-1234-123456789abc-suffix";
+  const jwt =
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP8p4w62I";
+  const percentEncoded = "user%20token%3Dsecret%26scope%3Dadmin";
+
+  const nowMs = Date.now();
+  const nowSec = Math.floor(nowMs / 1000);
+
+  beforeAll(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "firefox-raw-test-"));
+    schema15Dir = join(tempDir, "profile-schema15");
+    schema16Dir = join(tempDir, "profile-schema16");
+    mkdirSync(schema15Dir, { recursive: true });
+    mkdirSync(schema16Dir, { recursive: true });
+
+    schema15DbPath = join(schema15Dir, "cookies.sqlite");
+    schema16DbPath = join(schema16Dir, "cookies.sqlite");
+
+    // Containers config beside schema16 cookies.sqlite
+    writeFileSync(
+      join(schema16Dir, "containers.json"),
+      JSON.stringify({
+        containers: [
+          { userContextId: 1, name: "Personal" },
+          { userContextId: 2, name: "Work" },
+        ],
+      }),
+      "utf8",
+    );
+
+    // 1. Setup Schema 15 database (user_version = 15, expiry in SECONDS)
+    const db15 = new Database(schema15DbPath);
+    db15.pragma("user_version = 15");
+    db15.exec(`
+      CREATE TABLE moz_cookies (
+        id INTEGER PRIMARY KEY,
+        originAttributes TEXT NOT NULL DEFAULT '',
+        name TEXT,
+        value TEXT,
+        host TEXT,
+        path TEXT,
+        expiry INTEGER,
+        lastAccessed INTEGER,
+        creationTime INTEGER,
+        isSecure INTEGER,
+        isHttpOnly INTEGER,
+        inBrowserElement INTEGER DEFAULT 0,
+        sameSite INTEGER DEFAULT 0,
+        rawSameSite INTEGER DEFAULT 0,
+        schemeMap INTEGER DEFAULT 0
+      );
+    `);
+
+    const insert15 = db15.prepare(`
+      INSERT INTO moz_cookies (
+        originAttributes, name, value, host, path,
+        expiry, lastAccessed, creationTime, isSecure, isHttpOnly
+      ) VALUES (?, ?, ?, ?, ?, ?, 0, 0, ?, ?)
+    `);
+
+    // Schema 15: Valid unexpired cookie (expiry in seconds)
+    insert15.run(
+      "",
+      "auth_token",
+      rawAuthToken,
+      ".example.com",
+      "/api",
+      nowSec + 7200,
+      1,
+      1,
+    );
+
+    // Schema 15: Expired cookie (in seconds) - should be filtered out
+    insert15.run(
+      "",
+      "expired_cookie",
+      "old_val",
+      "example.com",
+      "/",
+      nowSec - 3600,
+      0,
+      0,
+    );
+
+    // Schema 15: Session cookie (expiry = 0) - should be filtered out
+    insert15.run("", "session_cookie", "sess_val", "example.com", "/", 0, 0, 0);
+
+    db15.close();
+
+    // 2. Setup Schema 16 database (user_version = 16, expiry in MILLISECONDS)
+    const db16 = new Database(schema16DbPath);
+    db16.pragma("user_version = 16");
+    db16.exec(`
+      CREATE TABLE moz_cookies (
+        id INTEGER PRIMARY KEY,
+        originAttributes TEXT NOT NULL DEFAULT '',
+        name TEXT,
+        value TEXT,
+        host TEXT,
+        path TEXT,
+        expiry INTEGER,
+        lastAccessed INTEGER,
+        creationTime INTEGER,
+        isSecure INTEGER,
+        isHttpOnly INTEGER,
+        inBrowserElement INTEGER DEFAULT 0,
+        sameSite INTEGER DEFAULT 0,
+        rawSameSite INTEGER DEFAULT 0,
+        schemeMap INTEGER DEFAULT 0
+      );
+    `);
+
+    const insert16 = db16.prepare(`
+      INSERT INTO moz_cookies (
+        originAttributes, name, value, host, path,
+        expiry, lastAccessed, creationTime, isSecure, isHttpOnly
+      ) VALUES (?, ?, ?, ?, ?, ?, 0, 0, ?, ?)
+    `);
+
+    // Schema 16: Future cookie with userContextId=2 (Work container)
+    insert16.run(
+      "^userContextId=2",
+      "jwt_work",
+      jwt,
+      "example.com",
+      "/work",
+      nowMs + 7200000,
+      1,
+      0,
+    );
+
+    // Schema 16: Future cookie with no container
+    insert16.run(
+      "",
+      "default_token",
+      percentEncoded,
+      "example.com",
+      "/",
+      nowMs + 7200000,
+      0,
+      1,
+    );
+
+    // Schema 16: Partitioned cookie via partitionKey
+    insert16.run(
+      "^partitionKey=(https,example.com)&userContextId=2",
+      "part_key_cookie",
+      "partition_val",
+      ".example.com",
+      "/part",
+      nowMs + 7200000,
+      1,
+      1,
+    );
+
+    // Schema 16: Partitioned cookie via firstPartyDomain
+    insert16.run(
+      "^firstPartyDomain=example.com",
+      "fpd_cookie",
+      "fpd_val",
+      "example.com",
+      "/fpd",
+      nowMs + 7200000,
+      0,
+      0,
+    );
+
+    // Schema 16: Expired cookie (in ms) - should be filtered out
+    insert16.run(
+      "",
+      "expired_ms_cookie",
+      "expired",
+      "example.com",
+      "/",
+      nowMs - 3600000,
+      0,
+      0,
+    );
+
+    db16.close();
+  });
+
+  afterAll(() => {
+    try {
+      rmSync(tempDir, { recursive: true, force: true });
+    } catch {
+      // Ignore cleanup errors
+    }
+  });
+
+  it("converts schema < 16 seconds expiry and filters expired rows in raw mode", async () => {
+    const strategy = new FirefoxCookieQueryStrategy();
+
+    const cookies = await withRawCookieValues(async () =>
+      strategy.queryCookies("%", "%", schema15DbPath),
+    );
+
+    expect(cookies).toHaveLength(1);
+    const [cookie] = cookies;
+    expect(cookie?.name).toBe("auth_token");
+    expect(cookie?.value).toBe(rawAuthToken);
+    expect(cookie?.domain).toBe(".example.com");
+    expect(cookie?.expiry).toBeInstanceOf(Date);
+    // Expiry converted from seconds to Date (within 10s tolerance)
+    expect((cookie?.expiry as Date).getTime()).toBeGreaterThan(nowMs);
+    expect(cookie?.meta).toMatchObject({
+      file: schema15DbPath,
+      browser: "Firefox",
+      decrypted: false,
+      secure: true,
+      httpOnly: true,
+      path: "/api",
+      hostOnly: false,
+      partitioned: false,
+    });
+    expect(cookie?.meta?.containerId).toBeUndefined();
+  });
+
+  it("converts schema >= 16 milliseconds expiry, handles containers and partitions", async () => {
+    const strategy = new FirefoxCookieQueryStrategy();
+
+    const cookies = await withRawCookieValues(async () =>
+      strategy.queryCookies("%", "%", schema16DbPath),
+    );
+
+    // Should include jwt_work, default_token, part_key_cookie, fpd_cookie (and exclude expired_ms_cookie)
+    expect(cookies).toHaveLength(4);
+
+    const workCookie = cookies.find((c) => c.name === "jwt_work");
+    expect(workCookie).toBeDefined();
+    expect(workCookie?.value).toBe(jwt);
+    expect(workCookie?.meta).toMatchObject({
+      path: "/work",
+      secure: true,
+      httpOnly: false,
+      hostOnly: true,
+      partitioned: false,
+      containerId: 2,
+    });
+
+    const defaultCookie = cookies.find((c) => c.name === "default_token");
+    expect(defaultCookie).toBeDefined();
+    expect(defaultCookie?.value).toBe(percentEncoded);
+    expect(defaultCookie?.meta).toMatchObject({
+      path: "/",
+      secure: false,
+      httpOnly: true,
+      hostOnly: true,
+      partitioned: false,
+    });
+    expect(defaultCookie?.meta?.containerId).toBeUndefined();
+
+    const partCookie = cookies.find((c) => c.name === "part_key_cookie");
+    expect(partCookie).toBeDefined();
+    expect(partCookie?.meta).toMatchObject({
+      path: "/part",
+      partitioned: true,
+      containerId: 2,
+    });
+
+    const fpdCookie = cookies.find((c) => c.name === "fpd_cookie");
+    expect(fpdCookie).toBeDefined();
+    expect(fpdCookie?.meta).toMatchObject({
+      path: "/fpd",
+      partitioned: true,
+    });
+  });
+
+  it("filters cookies by container option (numeric, 'none', and named from containers.json)", async () => {
+    // 1. Filter by numeric container ID (userContextId = 2)
+    const workStrategy = new FirefoxCookieQueryStrategy(undefined, 2);
+    const workCookies = await withRawCookieValues(async () =>
+      workStrategy.queryCookies("%", "%", schema16DbPath),
+    );
+    expect(workCookies.every((c) => c.meta?.containerId === 2)).toBe(true);
+    expect(workCookies.some((c) => c.name === "jwt_work")).toBe(true);
+    expect(workCookies.some((c) => c.name === "default_token")).toBe(false);
+
+    // 2. Filter by 'none' (default container without userContextId)
+    const noneStrategy = new FirefoxCookieQueryStrategy(undefined, "none");
+    const noneCookies = await withRawCookieValues(async () =>
+      noneStrategy.queryCookies("%", "%", schema16DbPath),
+    );
+    expect(noneCookies.every((c) => c.meta?.containerId === undefined)).toBe(
+      true,
+    );
+    expect(noneCookies.some((c) => c.name === "default_token")).toBe(true);
+    expect(noneCookies.some((c) => c.name === "jwt_work")).toBe(false);
+
+    // 3. Filter by named container ('work' resolves to userContextId = 2 via containers.json)
+    const namedStrategy = new FirefoxCookieQueryStrategy(undefined, "work");
+    const namedCookies = await withRawCookieValues(async () =>
+      namedStrategy.queryCookies("%", "%", schema16DbPath),
+    );
+    expect(namedCookies.every((c) => c.meta?.containerId === 2)).toBe(true);
+    expect(namedCookies.some((c) => c.name === "jwt_work")).toBe(true);
+  });
+
+  it("preserves display-mode compatibility and isolates concurrent raw and display calls", async () => {
+    const strategy = new FirefoxCookieQueryStrategy();
+
+    const [rawCookies, displayCookies] = await Promise.all([
+      withRawCookieValues(async () =>
+        strategy.queryCookies("%", "%", schema16DbPath),
+      ),
+      strategy.queryCookies("%", "%", schema16DbPath),
+    ]);
+
+    const rawWork = rawCookies.find((c) => c.name === "jwt_work");
+    const displayWork = displayCookies.find((c) => c.name === "jwt_work");
+
+    expect(rawWork?.value).toBe(jwt);
+    expect(rawWork?.meta?.path).toBe("/work");
+    expect(rawWork?.meta?.secure).toBe(true);
+    expect(rawWork?.meta?.containerId).toBe(2);
+
+    expect(displayWork?.value).toBe(jwt);
+    // Display mode does not include request metadata
+    expect(displayWork?.meta?.path).toBeUndefined();
+    expect(displayWork?.meta?.secure).toBeUndefined();
+    expect(displayWork?.meta?.hostOnly).toBeUndefined();
+    expect(displayWork?.meta?.partitioned).toBeUndefined();
+    // containerId is retained for display purposes
+    expect(displayWork?.meta?.containerId).toBe(2);
+  });
+});

--- a/src/core/browsers/safari/SafariCookieQueryStrategy.ts
+++ b/src/core/browsers/safari/SafariCookieQueryStrategy.ts
@@ -399,6 +399,12 @@ export class SafariCookieQueryStrategy extends BaseCookieQueryStrategy {
         secure: this.isFlagSet(cookieObj.flags, 0x1),
         httpOnly: this.isFlagSet(cookieObj.flags, 0x4),
         path: cookieObj.path ?? undefined,
+        ...(usesRawCookieValues() && {
+          hostOnly:
+            typeof cookieObj.domain === "string"
+              ? !cookieObj.domain.startsWith(".")
+              : true,
+        }),
         version:
           cookieObj.version === undefined ? undefined : cookieObj.version,
         comment: cookieObj.comment ?? undefined,

--- a/src/core/browsers/safari/__tests__/SafariCookieQueryStrategy.raw.test.ts
+++ b/src/core/browsers/safari/__tests__/SafariCookieQueryStrategy.raw.test.ts
@@ -1,0 +1,281 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { withRawCookieValues } from "../../../cookies/CookieQueryContext";
+import { BinaryCodableCookie } from "../BinaryCodableCookie";
+import { SafariCookieQueryStrategy } from "../SafariCookieQueryStrategy";
+
+interface CookieParams {
+  url: string;
+  name: string;
+  path: string;
+  value: string;
+  flags?: number;
+  expiration?: number;
+  creation?: number;
+}
+
+function buildCookieBuffer(params: CookieParams): Buffer {
+  const urlBuf = Buffer.from(`${params.url}\0`, "utf8");
+  const nameBuf = Buffer.from(`${params.name}\0`, "utf8");
+  const pathBuf = Buffer.from(`${params.path}\0`, "utf8");
+  const valBuf = Buffer.from(`${params.value}\0`, "utf8");
+
+  const headerSize = 56;
+  const urlOffset = headerSize;
+  const nameOffset = urlOffset + urlBuf.length;
+  const pathOffset = nameOffset + nameBuf.length;
+  const valueOffset = pathOffset + pathBuf.length;
+  const totalSize = valueOffset + valBuf.length;
+
+  const buf = Buffer.alloc(totalSize);
+  buf.writeUInt32LE(totalSize, 0);
+  buf.writeUInt32LE(0, 4); // version
+  buf.writeUInt32LE(params.flags ?? 0, 8);
+  buf.writeUInt32LE(0, 12); // hasPort = 0
+  buf.writeUInt32LE(urlOffset, 16);
+  buf.writeUInt32LE(nameOffset, 20);
+  buf.writeUInt32LE(pathOffset, 24);
+  buf.writeUInt32LE(valueOffset, 28);
+  buf.writeUInt32LE(0, 32); // commentOffset
+  buf.writeUInt32LE(0, 36); // commentURLOffset
+  // Timestamps: seconds since 2001-01-01 (Mac epoch)
+  buf.writeDoubleLE(params.expiration ?? 800000000, 40);
+  buf.writeDoubleLE(params.creation ?? 700000000, 48);
+
+  urlBuf.copy(buf, urlOffset);
+  nameBuf.copy(buf, nameOffset);
+  pathBuf.copy(buf, pathOffset);
+  valBuf.copy(buf, valueOffset);
+
+  return buf;
+}
+
+function buildBinaryCookiesFile(cookieBuffers: Buffer[]): Buffer {
+  const headerSize = 4 + 4 + cookieBuffers.length * 4 + 4;
+  let currentOffset = headerSize;
+  const offsets: number[] = [];
+  for (const cb of cookieBuffers) {
+    offsets.push(currentOffset);
+    currentOffset += cb.length;
+  }
+
+  const pageBuffer = Buffer.alloc(currentOffset);
+  pageBuffer.writeUInt32BE(0x00000100, 0); // page header
+  pageBuffer.writeUInt32LE(cookieBuffers.length, 4);
+  for (let i = 0; i < offsets.length; i++) {
+    pageBuffer.writeUInt32LE(offsets[i]!, 8 + i * 4);
+  }
+  pageBuffer.writeUInt32BE(0x00000000, 8 + cookieBuffers.length * 4); // page footer
+
+  for (let i = 0; i < cookieBuffers.length; i++) {
+    cookieBuffers[i]!.copy(pageBuffer, offsets[i]);
+  }
+
+  const totalLength = 4 + 4 + 4 + pageBuffer.length + 4 + 8;
+  const fileBuffer = Buffer.alloc(totalLength);
+  fileBuffer.write("cook", 0, 4, "utf8");
+  fileBuffer.writeUInt32BE(1, 4); // 1 page
+  fileBuffer.writeUInt32BE(pageBuffer.length, 8); // page size
+  pageBuffer.copy(fileBuffer, 12);
+  const checksumOffset = 12 + pageBuffer.length;
+  fileBuffer.writeUInt32BE(0, checksumOffset);
+  fileBuffer.writeBigUInt64BE(BigInt("0x071720050000004b"), checksumOffset + 4);
+
+  return fileBuffer;
+}
+
+describe("SafariCookieQueryStrategy & BinaryCodableCookie — raw values & metadata", () => {
+  let tempDir: string;
+  let cookieFilePath: string;
+
+  const rawAuthToken = "prefix-12345678-1234-1234-1234-123456789abc-suffix";
+  const jwt =
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP8p4w62I";
+  const percentEncoded = "user%20token%3Dsecret%26role%3Dadmin%2Bwrite";
+  const jsonString = '{"user_id":123,"role":"admin"}';
+
+  beforeAll(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "safari-raw-test-"));
+    cookieFilePath = join(tempDir, "Cookies.binarycookies");
+
+    const cookies = [
+      buildCookieBuffer({
+        url: ".example.com",
+        name: "auth_token",
+        path: "/api",
+        value: rawAuthToken,
+        flags: 0x5, // Secure (0x1) + HttpOnly (0x4)
+      }),
+      buildCookieBuffer({
+        url: "example.com",
+        name: "jwt_token",
+        path: "/",
+        value: jwt,
+        flags: 0x1, // Secure (0x1)
+      }),
+      buildCookieBuffer({
+        url: "example.com",
+        name: "encoded_token",
+        path: "/encoded",
+        value: percentEncoded,
+        flags: 0x4, // HttpOnly (0x4)
+      }),
+      buildCookieBuffer({
+        url: ".example.com",
+        name: "json_cookie",
+        path: "/json",
+        value: jsonString,
+        flags: 0x0,
+      }),
+    ];
+
+    const fileBuffer = buildBinaryCookiesFile(cookies);
+    writeFileSync(cookieFilePath, fileBuffer);
+  });
+
+  afterAll(() => {
+    try {
+      rmSync(tempDir, { recursive: true, force: true });
+    } catch {
+      // Ignore cleanup error
+    }
+  });
+
+  describe("Layer 1: BinaryCodableCookie.toCookieRow()", () => {
+    it("preserves percent-encoded values, JWTs and JSON strings in raw mode", async () => {
+      const encBuf = buildCookieBuffer({
+        url: "example.com",
+        name: "test_encoded",
+        path: "/",
+        value: percentEncoded,
+      });
+      const jwtBuf = buildCookieBuffer({
+        url: "example.com",
+        name: "test_jwt",
+        path: "/",
+        value: jwt,
+      });
+      const jsonBuf = buildCookieBuffer({
+        url: "example.com",
+        name: "test_json",
+        path: "/",
+        value: jsonString,
+      });
+
+      const [rawEnc, rawJwt, rawJson] = await Promise.all([
+        withRawCookieValues(async () =>
+          new BinaryCodableCookie(encBuf).toCookieRow(),
+        ),
+        withRawCookieValues(async () =>
+          new BinaryCodableCookie(jwtBuf).toCookieRow(),
+        ),
+        withRawCookieValues(async () =>
+          new BinaryCodableCookie(jsonBuf).toCookieRow(),
+        ),
+      ]);
+
+      expect(rawEnc?.value).toBe(percentEncoded);
+      expect(rawJwt?.value).toBe(jwt);
+      expect(rawJson?.value).toBe(jsonString);
+    });
+
+    it("decodes URL encoding, JSON or JWT in display mode without withRawCookieValues()", () => {
+      const encBuf = buildCookieBuffer({
+        url: "example.com",
+        name: "test_encoded",
+        path: "/",
+        value: percentEncoded,
+      });
+      const jsonBuf = buildCookieBuffer({
+        url: "example.com",
+        name: "test_json",
+        path: "/",
+        value: jsonString,
+      });
+
+      const displayEnc = new BinaryCodableCookie(encBuf).toCookieRow();
+      const displayJson = new BinaryCodableCookie(jsonBuf).toCookieRow();
+
+      // Display mode URL-decodes percentEncoded
+      expect(displayEnc?.value).toBe("user token=secret&role=admin+write");
+      // Display mode parses JSON into an object
+      expect(displayJson?.value).toEqual({ user_id: 123, role: "admin" });
+    });
+  });
+
+  describe("Layer 2: SafariCookieQueryStrategy.queryCookies()", () => {
+    it("preserves raw wire values and retains metadata through full strategy query", async () => {
+      const strategy = new SafariCookieQueryStrategy();
+
+      const cookies = await withRawCookieValues(async () =>
+        strategy.queryCookies("%", "%", cookieFilePath),
+      );
+
+      expect(cookies).toHaveLength(4);
+
+      const authCookie = cookies.find((c) => c.name === "auth_token");
+      expect(authCookie).toBeDefined();
+      expect(authCookie?.value).toBe(rawAuthToken);
+      expect(authCookie?.domain).toBe("example.com");
+      expect(authCookie?.meta).toMatchObject({
+        file: cookieFilePath,
+        browser: "Safari",
+        decrypted: false,
+        secure: true,
+        httpOnly: true,
+        path: "/api",
+        hostOnly: false, // url had leading dot ".example.com"
+      });
+
+      const jwtCookie = cookies.find((c) => c.name === "jwt_token");
+      expect(jwtCookie).toBeDefined();
+      expect(jwtCookie?.value).toBe(jwt);
+      expect(jwtCookie?.meta).toMatchObject({
+        secure: true,
+        httpOnly: false,
+        path: "/",
+        hostOnly: true, // url had no leading dot "example.com"
+      });
+
+      const encCookie = cookies.find((c) => c.name === "encoded_token");
+      expect(encCookie).toBeDefined();
+      expect(encCookie?.value).toBe(percentEncoded);
+      expect(encCookie?.meta).toMatchObject({
+        secure: false,
+        httpOnly: true,
+        path: "/encoded",
+        hostOnly: true,
+      });
+
+      const jsonCookie = cookies.find((c) => c.name === "json_cookie");
+      expect(jsonCookie).toBeDefined();
+      expect(jsonCookie?.value).toBe(jsonString);
+      expect(jsonCookie?.meta?.hostOnly).toBe(false);
+    });
+
+    it("isolates concurrent raw and display queries without cross-talk", async () => {
+      const strategy = new SafariCookieQueryStrategy();
+
+      const [rawCookies, displayCookies] = await Promise.all([
+        withRawCookieValues(async () =>
+          strategy.queryCookies("%", "%", cookieFilePath),
+        ),
+        strategy.queryCookies("%", "%", cookieFilePath),
+      ]);
+
+      const rawEnc = rawCookies.find((c) => c.name === "encoded_token");
+      const displayEnc = displayCookies.find((c) => c.name === "encoded_token");
+
+      // Raw mode keeps the percent-encoded string intact
+      expect(rawEnc?.value).toBe(percentEncoded);
+      expect(rawEnc?.meta?.hostOnly).toBe(true);
+
+      // Display mode URL-decodes the value
+      expect(displayEnc?.value).toBe("user token=secret&role=admin+write");
+      // Display mode does not include hostOnly
+      expect(displayEnc?.meta?.hostOnly).toBeUndefined();
+    });
+  });
+});

--- a/src/core/browsers/safari/__tests__/SafariCookieQueryStrategy.raw.test.ts
+++ b/src/core/browsers/safari/__tests__/SafariCookieQueryStrategy.raw.test.ts
@@ -6,6 +6,18 @@ import { withRawCookieValues } from "../../../cookies/CookieQueryContext";
 import { BinaryCodableCookie } from "../BinaryCodableCookie";
 import { SafariCookieQueryStrategy } from "../SafariCookieQueryStrategy";
 
+// Mock platform utilities so Safari strategy executes on Linux/Windows CI
+jest.mock("@utils/platformUtils", () => ({
+  ...jest.requireActual("@utils/platformUtils"),
+  isMacOS: jest.fn().mockReturnValue(true),
+}));
+
+// Mock SystemPermissions utilities
+jest.mock("@utils/systemPermissions", () => ({
+  checkFilePermission: jest.fn().mockResolvedValue(true),
+  handleSafariPermissionError: jest.fn().mockResolvedValue(false),
+}));
+
 interface CookieParams {
   url: string;
   name: string;

--- a/src/core/browsers/sql/CookieQueryBuilder.ts
+++ b/src/core/browsers/sql/CookieQueryBuilder.ts
@@ -418,6 +418,7 @@ export class CookieQueryBuilder {
    * @param domain - Domain name for filtering
    * @param exactDomain - Whether to use exact domain matching
    * @param includeExpired - Whether to include expired cookies
+   * @param container
    * @returns Object containing WHERE clause SQL and parameter values
    */
   private buildWhereClause(

--- a/src/core/cookies/CookieQueryContext.ts
+++ b/src/core/cookies/CookieQueryContext.ts
@@ -6,7 +6,6 @@ const context = new AsyncLocalStorage<{ rawValues: boolean }>();
 
 /**
  * Checks whether the current async context requires raw cookie values.
- *
  * @returns True if raw cookie values should be preserved, false otherwise.
  */
 export function usesRawCookieValues(): boolean {
@@ -15,7 +14,6 @@ export function usesRawCookieValues(): boolean {
 
 /**
  * Executes an asynchronous operation with raw cookie values preserved.
- *
  * @param operation - The asynchronous callback to execute within this context.
  * @returns The resolved result of the operation.
  */

--- a/src/core/cookies/batchGetCookies.ts
+++ b/src/core/cookies/batchGetCookies.ts
@@ -182,14 +182,13 @@ async function processChunkWithResults(
 
 /**
  * Retrieves multiple cookie specifications with detailed results for each spec
- *
+ * @param specs - Array of cookie specifications to retrieve
+ * @param options - Options for batch retrieval
+ * @returns Array of batch results with cookies and potential errors
  * @remarks
  * Detailed grouping currently matches exact cookie names and domains. Prefer
  * `batchGetCookies` or individual queries when wildcard names or
  * parent-domain matches matter.
- * @param specs - Array of cookie specifications to retrieve
- * @param options - Options for batch retrieval
- * @returns Array of batch results with cookies and potential errors
  */
 export async function batchGetCookiesWithResults(
   specs: CookieSpec[],

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,9 @@ export { ChromeCookieQueryStrategy } from "./core/browsers/chrome/ChromeCookieQu
  * Chromium-based browser cookie query strategy for browsers like Edge, Brave, etc.
  */
 export { ChromiumCookieQueryStrategy } from "./core/browsers/chromium/ChromiumCookieQueryStrategy";
+/**
+ *
+ */
 export {
   getChromiumProfiles,
   type ChromiumProfile,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,4 @@
 /**
- * Core cookie retrieval function (main entry point)
- */
-
-/**
  * Composite strategy that queries cookies from multiple browser strategies in parallel
  */
 export { CompositeCookieQueryStrategy } from "./core/browsers/CompositeCookieQueryStrategy";
@@ -16,7 +12,7 @@ export { ChromeCookieQueryStrategy } from "./core/browsers/chrome/ChromeCookieQu
  */
 export { ChromiumCookieQueryStrategy } from "./core/browsers/chromium/ChromiumCookieQueryStrategy";
 /**
- *
+ * Discover installed Chromium browser profiles
  */
 export {
   getChromiumProfiles,

--- a/src/mcp/cookies.ts
+++ b/src/mcp/cookies.ts
@@ -28,7 +28,6 @@ export type CookieReader = (
 
 /**
  * Computes the domain hierarchy for cookie matching from a given hostname.
- *
  * @param host - Target hostname to analyze.
  * @returns Array of parent and exact domain candidates.
  */
@@ -48,7 +47,6 @@ export function cookieDomains(host: string): string[] {
 
 /**
  * Default reader implementation querying local browser cookie stores.
- *
  * @param url - Destination URL.
  * @param selection - Browser and profile selection options.
  * @returns Promise resolving to matching exported cookies.
@@ -87,7 +85,6 @@ export const readCookies: CookieReader = async (url, selection) => {
 
 /**
  * Checks whether a cookie matches a destination URL according to domain, path, secure, and expiry rules.
- *
  * @param cookie - The exported cookie to test.
  * @param url - Destination URL to match against.
  * @param now - Current timestamp in milliseconds (defaults to Date.now()).
@@ -160,7 +157,6 @@ export function cookieMatchesUrl(
 
 /**
  * Queries and filters cookies applicable to a URL, deduplicating conflicting values.
- *
  * @param url - Destination URL.
  * @param selection - Cookie selection criteria.
  * @param reader - Underlying cookie reading function.
@@ -200,7 +196,6 @@ export async function selectCookies(
 
 /**
  * Builds an HTTP Cookie header string from an array of applicable cookies.
- *
  * @param cookies - Array of cookies to serialize.
  * @returns Formatted Cookie header value.
  */

--- a/src/mcp/fetch.ts
+++ b/src/mcp/fetch.ts
@@ -69,7 +69,6 @@ async function readBody(response: Response, limit: number) {
 
 /**
  * Performs an HTTP request with local cookies attached, respecting origin and method policy.
- *
  * @param input - Request parameters and cookie selection criteria.
  * @param policy - Security policy enforcing origin and method constraints.
  * @param reader - Function for extracting local cookies.

--- a/src/mcp/policy.ts
+++ b/src/mcp/policy.ts
@@ -16,7 +16,6 @@ export class McpOperationError extends Error {}
 
 /**
  * Parses and validates an absolute HTTP or HTTPS URL string.
- *
  * @param value - The raw URL string to validate.
  * @returns The parsed URL instance.
  * @throws McpOperationError if URL is invalid, non-HTTP(S), or contains credentials/fragments.
@@ -44,7 +43,6 @@ export function parseHttpUrl(value: string): URL {
 
 /**
  * Validates that the provided URL belongs to an allowed origin per the given policy.
- *
  * @param value - The raw URL string to check.
  * @param policy - The active MCP policy containing allowed origins.
  * @returns The parsed and validated URL instance.
@@ -62,7 +60,6 @@ export function assertAllowedUrl(value: string, policy: McpPolicy): URL {
 
 /**
  * Parses command-line arguments for the MCP server subcommand.
- *
  * @param args - CLI arguments array passed after 'mcp'.
  * @returns Parsed McpPolicy and help flag.
  */

--- a/src/mcp/profiles.ts
+++ b/src/mcp/profiles.ts
@@ -7,7 +7,6 @@ import { fileExists } from "../core/browsers/runtime/FileSystemAdapter";
 
 /**
  * Lists available browser profiles for a given browser or across all supported browsers.
- *
  * @param browser - Optional browser name to filter profiles.
  * @returns Array of browser profile descriptors with browser, profile name, and directory path.
  */

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -79,7 +79,6 @@ async function execute(operation: () => Promise<Record<string, unknown>>) {
 
 /**
  * Creates and configures an MCP server instance with get-cookie tools.
- *
  * @param policy - Security policy defining allowed origins and permissions.
  * @param overrides - Optional dependency overrides for testing.
  * @returns Configured McpServer instance.
@@ -195,7 +194,6 @@ export function createMcpServer(
 
 /**
  * Starts the MCP server on stdio with the provided policy.
- *
  * @param policy - The security policy to enforce.
  */
 export async function startMcpServer(policy: McpPolicy): Promise<void> {

--- a/src/types/schemas.ts
+++ b/src/types/schemas.ts
@@ -208,6 +208,8 @@ export const CookieMetaSchema = z
     httpOnly: z.boolean().optional(),
     path: CookiePathSchema.optional(),
     containerId: z.number().int().optional(),
+    hostOnly: z.boolean().optional(),
+    partitioned: z.boolean().optional(),
   })
   .catchall(z.unknown());
 


### PR DESCRIPTION
## Summary
Resolves #592 by verifying and completing request-local raw cookie value extraction and metadata preservation across Chromium, Firefox, and Safari adapters.

### Changes
1. **Metadata & Schemas (`src/types/schemas.ts`)**:
   - Added `hostOnly` and `partitioned` optional boolean fields to `CookieMetaSchema`.
2. **Chromium Strategy (`src/core/browsers/chromium/BaseChromiumCookieQueryStrategy.ts`)**:
   - Retained request metadata on failed decryptions while keeping `decrypted: false` so request filters exclude them.
   - Added `BaseChromiumCookieQueryStrategy.raw.test.ts` covering raw value fidelity (UUID patterns, percent-encoded, JWTs), modern schema partition detection (`top_frame_site_key`), legacy schema fallback, plaintext fallback when `encrypted_value` is empty, failed decryption exclusion, and concurrency isolation against display queries.
3. **Firefox Strategy (`src/core/browsers/firefox/FirefoxCookieQueryStrategy.ts`)**:
   - Added `FirefoxCookieQueryStrategy.raw.test.ts` covering schema-aware expiry (<16 seconds vs >=16 ms), expired cookie filtering, container filtering (numeric ID, `none`, named container from `containers.json`), partition mapping via `originAttributes`, and concurrency isolation.
4. **Safari Strategy (`src/core/browsers/safari/SafariCookieQueryStrategy.ts`)**:
   - Added conditional `hostOnly` calculation (`!domain.startsWith(".")`) under raw cookie mode.
   - Added `SafariCookieQueryStrategy.raw.test.ts` testing both mapping layers (`BinaryCodableCookie.toCookieRow()` and `SafariCookieQueryStrategy.queryCookies()`) against synthetic binary cookie stores, verifying raw wire string preservation for percent-encoded values, JWTs, and JSON structures without presentation decoding.
5. **Decryption & Validation**:
   - Expanded `decrypt.raw.test.ts` to test UUID substrings, percent-encoded strings, and JWTs under `withRawCookieValues()`.
   - Full validation (`pnpm run validate`) passes cleanly.

Closes #592
