### PR TITLE
feat(mcp): simplify profile discovery and request diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,20 @@ builds wildcard specs for a hostname and its parent domains without excluding
 public suffixes such as `co.uk`. Inspect results locally; do not pipe
 rendered output into an outgoing request.
 
+## Use it as an MCP server
+
+The MCP server lets agents find browser profiles containing a site's cookies
+and make authenticated requests with them. From a local checkout:
+
+```bash
+pnpm run build
+codex mcp add get-cookie -- pnpm --dir /absolute/path/to/get-cookie exec tsx /absolute/path/to/get-cookie/dist/cli.cjs mcp --allow-origin https://app.example.com
+```
+
+Call `get_status`, then `list_profiles` with a destination URL to find the
+right profile. Pass that profile to `authenticated_fetch`. See the
+[MCP guide](docs/automation/mcp.md) for setup, examples and proxy configuration.
+
 ## Use it from TypeScript
 
 Install the library:

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -32,6 +32,7 @@ export default defineConfig({
           text: "Use get-cookie",
           items: [
             { text: "CLI reference", link: "/guide/cli-usage" },
+            { text: "MCP server", link: "/automation/mcp" },
             { text: "Library usage", link: "/guide/api-usage" },
             { text: "Examples", link: "/guide/examples" },
             { text: "Automation", link: "/automation/" },
@@ -60,6 +61,7 @@ export default defineConfig({
           text: "Automation",
           items: [
             { text: "Overview", link: "/automation/" },
+            { text: "MCP server", link: "/automation/mcp" },
             { text: "Shell recipes", link: "/automation/shell-scripts" },
             {
               text: "Browser automation",

--- a/docs/automation/index.md
+++ b/docs/automation/index.md
@@ -16,6 +16,8 @@ storage on the current machine; it is not a credential-management system.
 
 ## Choose a path
 
+- [MCP server](/automation/mcp) lets agents find matching browser profiles
+  and make authenticated requests using your existing session.
 - [Shell scripts](/automation/shell-scripts) cover status-only local
   preflights and redacted metadata checks.
 - [Browser automation](/automation/browser-automation) covers metadata-only

--- a/docs/automation/mcp.md
+++ b/docs/automation/mcp.md
@@ -1,0 +1,165 @@
+---
+title: MCP server
+description: Use your browser session from an MCP client, discover matching profiles, and make authenticated requests.
+---
+
+# MCP server
+
+The MCP server lets an agent use your existing browser session. It can find
+the profile containing a site's cookies, inspect cookie metadata, and make
+HTTP requests using those cookies.
+
+## Install in Codex
+
+Build the checkout, then register its CLI:
+
+```bash
+pnpm install
+pnpm run build
+codex mcp add get-cookie -- pnpm --dir /absolute/path/to/get-cookie exec tsx /absolute/path/to/get-cookie/dist/cli.cjs mcp --allow-origin https://app.example.com
+```
+
+Replace `/absolute/path/to/get-cookie` with your checkout path. Registration
+uses the local build; rebuild after changing the source. Reconnect the MCP
+server in your client after changing its configuration.
+
+For other MCP clients, configure a stdio server using the same command and
+arguments:
+
+```json
+{
+  "mcpServers": {
+    "get-cookie": {
+      "command": "pnpm",
+      "args": [
+        "--dir", "/absolute/path/to/get-cookie",
+        "exec", "tsx", "/absolute/path/to/get-cookie/dist/cli.cjs",
+        "mcp", "--allow-origin", "https://app.example.com"
+      ]
+    }
+  }
+}
+```
+
+Repeat `--allow-origin` for additional sites. Each origin includes the scheme,
+hostname and optional port, such as `https://app.example.com` or
+`http://localhost:3000`. HTTP origins are supported on loopback only.
+
+## Find an account and make a request
+
+Start with `get_status` to see enabled origins, permitted methods and proxy
+environment configuration. Status reports configuration; it does not test
+connectivity.
+
+Find the Chrome profile containing a site's session cookie in one call:
+
+```json
+{
+  "name": "list_profiles",
+  "arguments": {
+    "browser": "chrome",
+    "url": "https://app.example.com/api/me",
+    "name": "sessionid"
+  }
+}
+```
+
+The result includes each profile's `cookieCount` and a `matchingProfiles`
+total. Select a profile with a positive count and pass its `name` as
+`profile`. If several profiles match, select the account needed for the task.
+
+For example, if the matching profile is called `Work`:
+
+```json
+{
+  "name": "authenticated_fetch",
+  "arguments": {
+    "browser": "chrome",
+    "profile": "Work",
+    "url": "https://app.example.com/api/me",
+    "name": "sessionid",
+    "method": "GET",
+    "maxResponseBytes": 1024
+  }
+}
+```
+
+The result contains the HTTP status, body, selected response headers, byte
+count, truncation flag and number of cookies sent. Cookie values remain in
+the server. Omit `name` when the request needs every applicable cookie from
+the selected profile. Use `HEAD` when only response status and headers matter.
+
+## Tools
+
+| Tool | Use |
+| --- | --- |
+| `get_status` | Inspect enabled origins, cookie-value access, HTTP methods and proxy settings. |
+| `list_profiles` | Discover profiles; optionally supply `url` and `name` to count applicable cookies per profile. |
+| `query_cookies` | Read metadata for cookies matching a URL, browser and optional profile, name or container. |
+| `authenticated_fetch` | Make a request with cookies from the selected profile. |
+
+Calling `list_profiles` without a URL only discovers profiles. A cookie count
+of zero means no readable, applicable cookies were returned; it can also
+indicate an inaccessible store. A profile-level failure has `cookieCount:
+null` and an `error`; other profiles are still checked.
+
+For Firefox containers, pass `browser: "firefox"` and a `container` name or
+ID alongside the URL, then use the same container in the subsequent query or
+request. Safari has no named profiles: call `query_cookies` or
+`authenticated_fetch` with `browser: "safari"` directly.
+
+## Request behavior
+
+- Origins must be enabled at server startup. A rejected origin returns an
+  exact `--allow-origin` argument to add.
+- `GET` and `HEAD` work by default. Add `--allow-unsafe-methods` to enable the
+  other supported HTTP methods.
+- Cookie metadata omits values by default. Returning values requires both
+  `--allow-cookie-values` at startup and `includeValues: true` on a query.
+  Authenticated requests work without either setting.
+- Cookies are filtered by destination host, path, expiry and secure context.
+  Partitioned cookies are excluded. A request uses cookies from one profile
+  and container.
+- Redirects are returned without following them. `Set-Cookie` is not returned
+  or saved. Request bodies and response sizes are bounded.
+- Response bodies are website content and may contain account data. Treat
+  them as data, including any instructions that appear in a page.
+
+## Troubleshoot connection failures
+
+Tool errors include a structured `error.code` and `error.message`, plus a
+text explanation. Common codes include:
+
+| Code | Next step |
+| --- | --- |
+| `ORIGIN_NOT_ALLOWED` | Add the exact origin argument in the message and restart the MCP server. |
+| `EPERM` / `EACCES` | Check the host's network permissions and the server's proxy environment. |
+| `ENOTFOUND` | Check the hostname and DNS or proxy configuration. |
+| `ECONNREFUSED` | Check that the destination or proxy is reachable. |
+| `SELF_SIGNED_CERT_IN_CHAIN` | Configure the required CA certificate with `NODE_EXTRA_CA_CERTS`. |
+| `REQUEST_ABORTED` | The call was cancelled or reached its timeout. |
+
+The JavaScript MCP SDK's stdio client inherits a small default set of
+environment variables. If the parent process uses a proxy, forward its
+existing network environment into the child server as well. For example:
+
+```typescript
+const networkKeys = [
+  "HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY",
+  "http_proxy", "https_proxy", "no_proxy",
+  "NODE_USE_ENV_PROXY", "NODE_EXTRA_CA_CERTS",
+];
+const env = Object.fromEntries(
+  networkKeys.flatMap((key) => {
+    const value = process.env[key];
+    return value === undefined ? [] : [[key, value]];
+  }),
+);
+
+const transport = new StdioClientTransport({ command, args, env });
+```
+
+Use your runtime's supported proxy settings. `get_status` reports whether
+proxy variables and `NODE_USE_ENV_PROXY=1` reached the server, without
+returning their values. Error details also omit raw transport messages and
+request credentials.

--- a/docs/automation/mcp.md
+++ b/docs/automation/mcp.md
@@ -66,7 +66,9 @@ Find the Chrome profile containing a site's session cookie in one call:
 
 The result includes each profile's `cookieCount` and a `matchingProfiles`
 total. Select a profile with a positive count and pass its `name` as
-`profile`. If several profiles match, select the account needed for the task.
+`profile`. For Firefox, also pass the returned `profileDirectory` unchanged;
+it identifies the exact store even when different installations use the same
+profile name. If several profiles match, select the account needed for the task.
 
 For example, if the matching profile is called `Work`:
 

--- a/docs/automation/mcp.md
+++ b/docs/automation/mcp.md
@@ -105,6 +105,13 @@ of zero means no readable, applicable cookies were returned; it can also
 indicate an inaccessible store. A profile-level failure has `cookieCount:
 null` and an `error`; other profiles are still checked.
 
+Supply `browser` to limit the work. With a URL and no browser filter, discovery
+reads and decrypts cookies across all discovered browsers and may trigger OS
+keychain prompts. Profiles are read sequentially with no per-profile timeout.
+Cancellation is checked between reads; a locked store or pending keychain
+prompt can delay cancellation until that read finishes. Use metadata-only
+discovery first when browser access is uncertain.
+
 For Firefox containers, pass `browser: "firefox"` and a `container` name or
 ID alongside the URL, then use the same container in the subsequent query or
 request. Safari has no named profiles: call `query_cookies` or

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -251,7 +251,7 @@ async function main(): Promise<void> {
     const policy = parseMcpArgs(args.slice(1));
     if (policy.help) {
       process.stderr.write(
-        "Usage: get-cookie mcp [--allow-origin https://example.com] [--allow-cookie-values] [--allow-unsafe-methods]\nRepeat --allow-origin for each origin. Without it only profile discovery is available. HTTP is allowed only on loopback.\n",
+        "Usage: get-cookie mcp [--allow-origin https://example.com] [--allow-cookie-values] [--allow-unsafe-methods]\nRepeat --allow-origin for each origin. Without it only server status and profile discovery are available. HTTP is allowed only on loopback.\nTools: get_status, list_profiles (optional URL and cookie name), query_cookies, authenticated_fetch.\n",
       );
       return;
     }

--- a/src/mcp/__tests__/fetch.test.ts
+++ b/src/mcp/__tests__/fetch.test.ts
@@ -119,4 +119,49 @@ describe("authenticated fetch", () => {
       authenticatedFetch({ ...input, timeoutMs: 20 }, policy, reader, request),
     ).rejects.toThrow("timed out");
   });
+  it.each([
+    ["EPERM", "HTTP_PROXY"],
+    ["ENOTFOUND", "hostname"],
+    ["ECONNREFUSED", "reachable"],
+    ["CERT_HAS_EXPIRED", "expired"],
+    ["SELF_SIGNED_CERT_IN_CHAIN", "NODE_EXTRA_CA_CERTS"],
+    ["UND_ERR_CONNECT_TIMEOUT", "timed out"],
+  ])("explains %s failures without exposing transport details", async (code, hint) => {
+    const cause = Object.assign(new Error("secret request details"), { code });
+    const error = Object.assign(new TypeError("secret cookie header"), {
+      cause,
+    });
+    const request = jest.fn<typeof fetch>().mockRejectedValue(error);
+    await expect(
+      authenticatedFetch(input, policy, reader, request),
+    ).rejects.toMatchObject({ code, message: expect.stringContaining(hint) });
+    await expect(
+      authenticatedFetch(input, policy, reader, request),
+    ).rejects.not.toThrow("secret");
+  });
+  it("recognizes errors nested inside AggregateError", async () => {
+    const error = Object.assign(new Error("secret"), {
+      cause: new AggregateError([
+        Object.assign(new Error("secret"), { code: "EACCES" }),
+      ]),
+    });
+    const request = jest.fn<typeof fetch>().mockRejectedValue(error);
+    await expect(
+      authenticatedFetch(input, policy, reader, request),
+    ).rejects.toMatchObject({ code: "EACCES" });
+  });
+  it("bounds circular error causes and hides unknown codes and raw messages", async () => {
+    const error: { message: string; code: string; cause?: unknown } = {
+      message: "secret",
+      code: "secret",
+    };
+    error.cause = error;
+    const request = jest.fn<typeof fetch>().mockRejectedValue(error);
+    await expect(
+      authenticatedFetch(input, policy, reader, request),
+    ).rejects.toMatchObject({
+      code: "FETCH_FAILED",
+      message: expect.not.stringContaining("secret"),
+    });
+  });
 });

--- a/src/mcp/__tests__/profiles.test.ts
+++ b/src/mcp/__tests__/profiles.test.ts
@@ -1,0 +1,26 @@
+import { FIREFOX_DATA_DIRS } from "../../core/browsers/BrowserAvailability";
+import { parseFirefoxProfilesIni } from "../../core/browsers/firefox/FirefoxCookieQueryStrategy";
+import { fileExists } from "../../core/browsers/runtime/FileSystemAdapter";
+import { listProfiles } from "../profiles";
+
+jest.mock("../../core/browsers/BrowserAvailability", () => ({
+  FIREFOX_DATA_DIRS: { [process.platform]: ["/firefox", "/firefox-esr"] },
+}));
+jest.mock("../../core/browsers/firefox/FirefoxCookieQueryStrategy");
+jest.mock("../../core/browsers/runtime/FileSystemAdapter");
+
+it("resolves relative Firefox directories against each installation root", () => {
+  jest.mocked(fileExists).mockReturnValue(true);
+  jest.mocked(parseFirefoxProfilesIni).mockReturnValue([
+    { name: "Work", path: "Profiles/default", isRelative: true },
+    { name: "External", path: resolve("/external/profile"), isRelative: false },
+  ]);
+  const { profiles } = listProfiles("firefox");
+  expect(profiles.map((profile) => profile.profileDirectory)).toEqual(
+    FIREFOX_DATA_DIRS[process.platform]!.flatMap((root) => [
+      resolve(root, "Profiles/default"),
+      resolve("/external/profile"),
+    ]),
+  );
+});
+import { resolve } from "node:path";

--- a/src/mcp/__tests__/profiles.test.ts
+++ b/src/mcp/__tests__/profiles.test.ts
@@ -1,3 +1,5 @@
+import { resolve } from "node:path";
+
 import { FIREFOX_DATA_DIRS } from "../../core/browsers/BrowserAvailability";
 import { parseFirefoxProfilesIni } from "../../core/browsers/firefox/FirefoxCookieQueryStrategy";
 import { fileExists } from "../../core/browsers/runtime/FileSystemAdapter";
@@ -23,4 +25,3 @@ it("resolves relative Firefox directories against each installation root", () =>
     ]),
   );
 });
-import { resolve } from "node:path";

--- a/src/mcp/__tests__/reader.test.ts
+++ b/src/mcp/__tests__/reader.test.ts
@@ -1,0 +1,70 @@
+import { createStrategy } from "../../core/browsers/StrategyFactory";
+import { readCookies } from "../cookies";
+import { listProfiles } from "../profiles";
+
+jest.mock("../../core/browsers/StrategyFactory");
+jest.mock("../profiles");
+
+const queryCookies = jest.fn().mockResolvedValue([]);
+const profileDirectory = resolve("/firefox-esr/Profiles/default");
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest
+    .mocked(createStrategy)
+    .mockReturnValue({ queryCookies } as unknown as ReturnType<
+      typeof createStrategy
+    >);
+  jest.mocked(listProfiles).mockReturnValue({
+    profiles: [
+      {
+        browser: "firefox",
+        name: "Work",
+        directory: "Profiles/default",
+        profileDirectory,
+      },
+    ],
+    note: "Fixture profiles.",
+  });
+});
+
+it("reads only the registered Firefox directory instead of all matching display names", async () => {
+  await readCookies(new URL("https://example.com"), {
+    browser: "firefox",
+    profile: "Work",
+    profileDirectory,
+    container: 3,
+  });
+  expect(createStrategy).toHaveBeenCalledWith({
+    browser: "firefox",
+    container: 3,
+  });
+  expect(queryCookies).toHaveBeenCalledTimes(1);
+  expect(queryCookies).toHaveBeenCalledWith(
+    "%",
+    "example.com",
+    join(profileDirectory, "cookies.sqlite"),
+    true,
+  );
+});
+
+it("rejects unknown directories before reading a store", async () => {
+  await expect(
+    readCookies(new URL("https://example.com"), {
+      browser: "firefox",
+      profileDirectory: "/unregistered/store",
+    }),
+  ).rejects.toMatchObject({ code: "PROFILE_NOT_FOUND" });
+  expect(createStrategy).not.toHaveBeenCalled();
+});
+
+it("rejects directory selection for other browsers", async () => {
+  await expect(
+    readCookies(new URL("https://example.com"), {
+      browser: "chrome",
+      profileDirectory,
+    }),
+  ).rejects.toThrow("only by Firefox");
+  expect(createStrategy).not.toHaveBeenCalled();
+});
+import { join, resolve } from "node:path";

--- a/src/mcp/__tests__/reader.test.ts
+++ b/src/mcp/__tests__/reader.test.ts
@@ -1,3 +1,5 @@
+import { join, resolve } from "node:path";
+
 import { createStrategy } from "../../core/browsers/StrategyFactory";
 import { readCookies } from "../cookies";
 import { listProfiles } from "../profiles";
@@ -67,4 +69,3 @@ it("rejects directory selection for other browsers", async () => {
   ).rejects.toThrow("only by Firefox");
   expect(createStrategy).not.toHaveBeenCalled();
 });
-import { join, resolve } from "node:path";

--- a/src/mcp/__tests__/server.test.ts
+++ b/src/mcp/__tests__/server.test.ts
@@ -1,0 +1,220 @@
+import { jest } from "@jest/globals";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+
+import type { CookieReader } from "../cookies";
+import { parseMcpArgs } from "../policy";
+import { createMcpServer } from "../server";
+
+const url = "https://example.com/api/me";
+const profiles = [
+  { browser: "firefox", name: "Personal", directory: "personal" },
+  { browser: "firefox", name: "Work", directory: "work" },
+  { browser: "firefox", name: "Unavailable", directory: "unavailable" },
+];
+const readCookies = jest.fn<CookieReader>();
+const listProfiles = jest.fn(() => ({ profiles, note: "Fixture profiles." }));
+const request = jest.fn<typeof fetch>();
+let server: ReturnType<typeof createMcpServer>;
+let client: Client;
+
+beforeEach(async () => {
+  jest.clearAllMocks();
+  readCookies.mockImplementation(async (_url, selection) => {
+    if (selection.profile === "Unavailable") {
+      throw new Error("unreadable fixture-secret");
+    }
+    if (selection.profile !== "Work") {
+      return [];
+    }
+    return [
+      {
+        domain: "example.com",
+        name: "session",
+        value: "fixture-secret",
+        meta: { browser: "Firefox", file: "work", path: "/api", secure: true },
+      },
+    ];
+  });
+  request.mockResolvedValue(new Response("signed in", { status: 200 }));
+  server = createMcpServer(
+    parseMcpArgs(["--allow-origin", "https://example.com"]),
+    {
+      readCookies,
+      listProfiles,
+      fetch: request,
+    },
+  );
+  client = new Client({ name: "mcp-test", version: "1.0.0" });
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+});
+
+afterEach(async () => {
+  await client.close();
+  await server.close();
+});
+
+it("reports capabilities without reading browser cookies", async () => {
+  const { tools } = await client.listTools();
+  expect(tools.map((tool) => tool.name)).toContain("get_status");
+  const result = await client.callTool({ name: "get_status", arguments: {} });
+  expect(result.structuredContent).toMatchObject({
+    allowedOrigins: ["https://example.com"],
+    cookieValuesEnabled: false,
+    allowedMethods: ["GET", "HEAD"],
+    network: {
+      proxyConfigured: expect.any(Boolean),
+      nodeUseEnvProxy: expect.any(Boolean),
+    },
+  });
+  expect(readCookies).not.toHaveBeenCalled();
+  expect(request).not.toHaveBeenCalled();
+});
+
+it("keeps plain profile discovery compatible and avoids cookie reads", async () => {
+  const result = await client.callTool({
+    name: "list_profiles",
+    arguments: { browser: "firefox" },
+  });
+  expect(result.structuredContent).toEqual({
+    profiles,
+    note: "Fixture profiles.",
+  });
+  expect(listProfiles).toHaveBeenCalledWith("firefox");
+  expect(readCookies).not.toHaveBeenCalled();
+});
+
+it("finds the matching profile and performs a request through the MCP client", async () => {
+  const discovered = await client.callTool({
+    name: "list_profiles",
+    arguments: { browser: "firefox", url, name: "session" },
+  });
+  expect(discovered.structuredContent).toMatchObject({
+    matchingProfiles: 1,
+    profiles: [
+      { name: "Personal", cookieCount: 0 },
+      { name: "Work", cookieCount: 1 },
+      {
+        name: "Unavailable",
+        cookieCount: null,
+        error: { code: "OPERATION_FAILED" },
+      },
+    ],
+  });
+  expect(JSON.stringify(discovered)).not.toContain("fixture-secret");
+  const selected = (
+    discovered.structuredContent as {
+      profiles: { name: string; browser: string; cookieCount: number | null }[];
+    }
+  ).profiles.find((p) => p.cookieCount === 1)!;
+  const args = {
+    browser: selected.browser,
+    profile: selected.name,
+    url,
+    name: "session",
+  };
+  const metadata = await client.callTool({
+    name: "query_cookies",
+    arguments: args,
+  });
+  expect(metadata.structuredContent).toMatchObject({
+    count: 1,
+    valuesIncluded: false,
+  });
+  expect(JSON.stringify(metadata)).not.toContain("fixture-secret");
+  const response = await client.callTool({
+    name: "authenticated_fetch",
+    arguments: args,
+  });
+  expect(response.structuredContent).toMatchObject({
+    status: 200,
+    cookiesSent: 1,
+    body: "signed in",
+  });
+  expect(new Headers(request.mock.calls[0]?.[1]?.headers).get("cookie")).toBe(
+    "session=fixture-secret",
+  );
+  expect(request.mock.calls[0]?.[1]?.redirect).toBe("manual");
+});
+
+it("checks origin access before inspecting profiles and provides exact setup arguments", async () => {
+  const result = await client.callTool({
+    name: "list_profiles",
+    arguments: {
+      url: "https://other.example.com:444/private?token=fixture-secret",
+    },
+  });
+  expect(result.isError).toBe(true);
+  expect(result.structuredContent).toMatchObject({
+    error: {
+      code: "ORIGIN_NOT_ALLOWED",
+      message: expect.stringContaining(
+        "--allow-origin https://other.example.com:444",
+      ),
+    },
+  });
+  expect(JSON.stringify(result)).not.toContain("fixture-secret");
+  expect(listProfiles).not.toHaveBeenCalled();
+  expect(readCookies).not.toHaveBeenCalled();
+});
+
+it("validates cookie filters and forwards Firefox containers", async () => {
+  for (const args of [{ name: "session" }, { container: "Work" }]) {
+    const result = await client.callTool({
+      name: "list_profiles",
+      arguments: args,
+    });
+    expect(result.structuredContent).toMatchObject({
+      error: { code: "URL_REQUIRED" },
+    });
+  }
+  const invalid = await client.callTool({
+    name: "list_profiles",
+    arguments: { url, container: "Work" },
+  });
+  expect(invalid.structuredContent).toMatchObject({
+    error: { code: "FIREFOX_REQUIRED" },
+  });
+  expect(readCookies).not.toHaveBeenCalled();
+  await client.callTool({
+    name: "list_profiles",
+    arguments: { url, browser: "firefox", container: 3, name: "session" },
+  });
+  expect(readCookies).toHaveBeenCalledWith(new URL(url), {
+    browser: "firefox",
+    profile: "Work",
+    container: 3,
+    name: "session",
+  });
+});
+
+it("counts only cookies applicable to the destination and exact name", async () => {
+  const result = await client.callTool({
+    name: "list_profiles",
+    arguments: { url: "https://example.com/elsewhere", name: "different" },
+  });
+  expect(result.structuredContent).toMatchObject({ matchingProfiles: 0 });
+});
+
+it("returns actionable transport errors without leaking their raw payloads", async () => {
+  request.mockRejectedValue(
+    Object.assign(new TypeError("fixture-secret"), {
+      cause: Object.assign(new Error("fixture-secret"), { code: "EPERM" }),
+    }),
+  );
+  const result = await client.callTool({
+    name: "authenticated_fetch",
+    arguments: { url, browser: "firefox", profile: "Work" },
+  });
+  expect(result.isError).toBe(true);
+  expect(result.structuredContent).toMatchObject({
+    error: {
+      code: "EPERM",
+      message: expect.stringContaining("NODE_USE_ENV_PROXY"),
+    },
+  });
+  expect(JSON.stringify(result)).not.toContain("fixture-secret");
+});

--- a/src/mcp/__tests__/server.test.ts
+++ b/src/mcp/__tests__/server.test.ts
@@ -218,3 +218,59 @@ it("returns actionable transport errors without leaking their raw payloads", asy
   });
   expect(JSON.stringify(result)).not.toContain("fixture-secret");
 });
+
+it("keeps same-name Firefox profiles separate through discovery and fetching", async () => {
+  const duplicates = [
+    "/firefox/Profiles/default",
+    "/firefox-esr/Profiles/default",
+  ].map((profileDirectory) => ({
+    browser: "firefox",
+    name: "Work",
+    directory: "Profiles/default",
+    profileDirectory,
+  }));
+  listProfiles.mockReturnValueOnce({
+    profiles: duplicates,
+    note: "Fixture profiles.",
+  });
+  readCookies.mockImplementation(async (_url, selection) => [
+    {
+      domain: "example.com",
+      name: "session",
+      value: "fixture-secret",
+      meta: {
+        browser: "Firefox",
+        file: `${selection.profileDirectory}/cookies.sqlite`,
+        path: "/",
+      },
+    },
+  ]);
+  const discovered = await client.callTool({
+    name: "list_profiles",
+    arguments: { browser: "firefox", url },
+  });
+  expect(discovered.structuredContent).toMatchObject({
+    matchingProfiles: 2,
+    profiles: duplicates.map((profile) => ({ ...profile, cookieCount: 1 })),
+  });
+  for (const profile of duplicates) {
+    expect(readCookies).toHaveBeenCalledWith(new URL(url), {
+      browser: "firefox",
+      profile: "Work",
+      profileDirectory: profile.profileDirectory,
+    });
+    const response = await client.callTool({
+      name: "authenticated_fetch",
+      arguments: {
+        browser: "firefox",
+        profile: "Work",
+        profileDirectory: profile.profileDirectory,
+        url,
+      },
+    });
+    expect(response.structuredContent).toMatchObject({
+      status: 200,
+      cookiesSent: 1,
+    });
+  }
+});

--- a/src/mcp/__tests__/server.test.ts
+++ b/src/mcp/__tests__/server.test.ts
@@ -274,3 +274,18 @@ it("keeps same-name Firefox profiles separate through discovery and fetching", a
     });
   }
 });
+
+it("uses the cancellation error code without exposing the abort reason", async () => {
+  readCookies.mockRejectedValue(
+    new DOMException("fixture-secret", "AbortError"),
+  );
+  const result = await client.callTool({
+    name: "query_cookies",
+    arguments: { url, browser: "firefox", profile: "Work" },
+  });
+  expect(result.isError).toBe(true);
+  expect(result.structuredContent).toMatchObject({
+    error: { code: "REQUEST_ABORTED" },
+  });
+  expect(JSON.stringify(result)).not.toContain("fixture-secret");
+});

--- a/src/mcp/cookies.ts
+++ b/src/mcp/cookies.ts
@@ -1,4 +1,5 @@
 import { isIP } from "node:net";
+import { join } from "node:path";
 
 import { getDomain } from "tldts";
 
@@ -7,6 +8,7 @@ import { withRawCookieValues } from "../core/cookies/CookieQueryContext";
 import type { ExportedCookie } from "../types/schemas";
 
 import { McpOperationError } from "./policy";
+import { listProfiles } from "./profiles";
 
 /**
  * Parameters for selecting cookies from a specific browser and store.
@@ -14,6 +16,7 @@ import { McpOperationError } from "./policy";
 export interface CookieSelection {
   browser: string;
   profile?: string | undefined;
+  profileDirectory?: string | undefined;
   container?: string | number | undefined;
   name?: string | undefined;
 }
@@ -52,6 +55,24 @@ export function cookieDomains(host: string): string[] {
  * @returns Promise resolving to matching exported cookies.
  */
 export const readCookies: CookieReader = async (url, selection) => {
+  let store: string | undefined;
+  if (selection.profileDirectory !== undefined) {
+    if (selection.browser !== "firefox") {
+      throw new McpOperationError(
+        "Profile directories are supported only by Firefox.",
+      );
+    }
+    const profile = listProfiles("firefox").profiles.find(
+      (candidate) => candidate.profileDirectory === selection.profileDirectory,
+    );
+    if (!profile) {
+      throw new McpOperationError(
+        "Profile directory is no longer available. Run list_profiles again.",
+        "PROFILE_NOT_FOUND",
+      );
+    }
+    store = join(selection.profileDirectory, "cookies.sqlite");
+  }
   if (selection.browser === "safari" && selection.profile) {
     throw new McpOperationError("Safari does not support named profiles.");
   }
@@ -61,7 +82,8 @@ export const readCookies: CookieReader = async (url, selection) => {
   return withRawCookieValues(async () => {
     const strategy = createStrategy({
       browser: selection.browser,
-      ...(selection.profile !== undefined && { profile: selection.profile }),
+      ...(store === undefined &&
+        selection.profile !== undefined && { profile: selection.profile }),
       ...(selection.browser === "firefox" && {
         container: selection.container ?? "none",
       }),
@@ -74,7 +96,7 @@ export const readCookies: CookieReader = async (url, selection) => {
         ...(await strategy.queryCookies(
           selection.name ?? "%",
           domain,
-          undefined,
+          store,
           true,
         )),
       );

--- a/src/mcp/fetch.ts
+++ b/src/mcp/fetch.ts
@@ -36,6 +36,65 @@ const RESPONSE_HEADERS = [
   "retry-after",
 ];
 
+const NETWORK_ERRORS = new Map(
+  Object.entries({
+    EPERM:
+      "Network access was denied. Check the MCP host's network permissions and pass HTTP_PROXY/HTTPS_PROXY and NODE_USE_ENV_PROXY to the server when required.",
+    EACCES:
+      "Network access was denied. Check the MCP host's network permissions and proxy configuration.",
+    ENOTFOUND:
+      "DNS lookup failed. Check the destination hostname and proxy configuration.",
+    EAI_AGAIN:
+      "DNS lookup temporarily failed. Check network connectivity and retry.",
+    ECONNREFUSED:
+      "The connection was refused. Check that the destination or configured proxy is reachable.",
+    ECONNRESET:
+      "The connection was reset. Check network connectivity and retry.",
+    ETIMEDOUT:
+      "The connection timed out. Check network connectivity and proxy configuration.",
+    UND_ERR_CONNECT_TIMEOUT:
+      "The connection timed out. Check network connectivity and proxy configuration.",
+    CERT_HAS_EXPIRED:
+      "A TLS certificate has expired. Check the destination or proxy certificate.",
+    DEPTH_ZERO_SELF_SIGNED_CERT:
+      "A TLS certificate is not trusted. Configure the required CA certificate with NODE_EXTRA_CA_CERTS.",
+    SELF_SIGNED_CERT_IN_CHAIN:
+      "A TLS certificate is not trusted. Configure the required CA certificate with NODE_EXTRA_CA_CERTS.",
+    UNABLE_TO_VERIFY_LEAF_SIGNATURE:
+      "A TLS certificate could not be verified. Configure the required CA certificate with NODE_EXTRA_CA_CERTS.",
+  }),
+);
+
+// Fetch wraps transport errors in `cause` (and sometimes AggregateError).
+// Return only known codes and our own messages, never credential-bearing errors.
+function networkErrorCode(error: unknown, depth = 0): string | undefined {
+  if (!error || typeof error !== "object" || depth > 4) {
+    return undefined;
+  }
+  if (
+    "code" in error &&
+    typeof error.code === "string" &&
+    NETWORK_ERRORS.has(error.code)
+  ) {
+    return error.code;
+  }
+  if ("cause" in error) {
+    const code = networkErrorCode(error.cause, depth + 1);
+    if (code) {
+      return code;
+    }
+  }
+  if (error instanceof AggregateError) {
+    for (const child of error.errors.slice(0, 8)) {
+      const code = networkErrorCode(child, depth + 1);
+      if (code) {
+        return code;
+      }
+    }
+  }
+  return undefined;
+}
+
 async function readBody(response: Response, limit: number) {
   if (!response.body) {
     return { body: "", truncated: false, bytes: 0 };
@@ -138,11 +197,19 @@ export async function authenticatedFetch(
       ...body,
       cookiesSent: cookies.length,
     };
-  } catch {
+  } catch (error) {
+    if (controller.signal.aborted) {
+      throw new McpOperationError(
+        "Request cancelled or timed out.",
+        "REQUEST_ABORTED",
+      );
+    }
+    const code = networkErrorCode(error);
     throw new McpOperationError(
-      controller.signal.aborted
-        ? "Request cancelled or timed out."
-        : "Authenticated request failed.",
+      code
+        ? `Authenticated request failed (${code}). ${NETWORK_ERRORS.get(code)}`
+        : "Authenticated request failed. Check network connectivity, proxy configuration and TLS certificates.",
+      code ?? "FETCH_FAILED",
     );
   } finally {
     clearTimeout(timer);

--- a/src/mcp/policy.ts
+++ b/src/mcp/policy.ts
@@ -12,7 +12,15 @@ export interface McpPolicy {
 /**
  * Error raised when an MCP tool operation or policy validation fails.
  */
-export class McpOperationError extends Error {}
+export class McpOperationError extends Error {
+  constructor(
+    message: string,
+    public readonly code = "OPERATION_FAILED",
+  ) {
+    super(message);
+    this.name = "McpOperationError";
+  }
+}
 
 /**
  * Parses and validates an absolute HTTP or HTTPS URL string.
@@ -52,7 +60,8 @@ export function assertAllowedUrl(value: string, policy: McpPolicy): URL {
   const url = parseHttpUrl(value);
   if (!policy.allowedOrigins.has(url.origin)) {
     throw new McpOperationError(
-      "Origin is not enabled. Add its exact scheme, host and port with --allow-origin at server startup.",
+      `Origin is not enabled. Add --allow-origin ${url.origin} to the MCP server arguments and restart the server. Call get_status to see enabled origins.`,
+      "ORIGIN_NOT_ALLOWED",
     );
   }
   return url;

--- a/src/mcp/profiles.ts
+++ b/src/mcp/profiles.ts
@@ -1,4 +1,4 @@
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 
 import { FIREFOX_DATA_DIRS } from "../core/browsers/BrowserAvailability";
 import { getChromiumProfiles } from "../core/browsers/chromium/getChromiumProfiles";
@@ -11,7 +11,12 @@ import { fileExists } from "../core/browsers/runtime/FileSystemAdapter";
  * @returns Array of browser profile descriptors with browser, profile name, and directory path.
  */
 export function listProfiles(browser?: string) {
-  const profiles: { browser: string; name: string; directory: string }[] = [];
+  const profiles: {
+    browser: string;
+    name: string;
+    directory: string;
+    profileDirectory?: string;
+  }[] = [];
   if (!browser || (browser !== "firefox" && browser !== "safari")) {
     profiles.push(
       ...getChromiumProfiles(browser).map((profile) => ({
@@ -32,6 +37,9 @@ export function listProfiles(browser?: string) {
           browser: "firefox",
           name: profile.name,
           directory: profile.path,
+          profileDirectory: profile.isRelative
+            ? resolve(dir, profile.path)
+            : resolve(profile.path),
         })),
       );
     }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -58,19 +58,28 @@ function result(output: Record<string, unknown>) {
   };
 }
 
+function operationError(error: unknown) {
+  return error instanceof McpOperationError
+    ? { code: error.code, message: error.message }
+    : {
+        code: "OPERATION_FAILED",
+        message:
+          "Operation failed. Check local browser access and server configuration.",
+      };
+}
+
 async function execute(operation: () => Promise<Record<string, unknown>>) {
   try {
     return result(await operation());
   } catch (error) {
+    const detail = operationError(error);
     return {
       isError: true,
+      structuredContent: { error: detail },
       content: [
         {
           type: "text" as const,
-          text:
-            error instanceof McpOperationError
-              ? error.message
-              : "Operation failed. Check local browser access and server configuration.",
+          text: detail.message,
         },
       ],
     };
@@ -93,19 +102,118 @@ export function createMcpServer(
     fetch,
     ...overrides,
   };
-  const server = new McpServer({ name: "get-cookie", version });
-  server.registerTool(
-    "list_profiles",
+  const server = new McpServer(
+    { name: "get-cookie", version },
     {
-      description: "List local browser profiles available for cookie access.",
-      inputSchema: { browser: browser.optional() },
+      instructions:
+        "Use get_status to inspect enabled origins. Call list_profiles with the destination URL and optional cookie name to find a matching profile in one call, then pass its browser and name as the profile to query_cookies or authenticated_fetch. Authenticated fetch uses cookies directly; reading their values is unnecessary.",
+    },
+  );
+  server.registerTool(
+    "get_status",
+    {
+      description:
+        "Show enabled origins, cookie-value access, HTTP methods and proxy environment configuration. Does not probe the network or read cookies.",
+      inputSchema: {},
       annotations: {
         readOnlyHint: true,
         destructiveHint: false,
         openWorldHint: false,
       },
     },
-    async ({ browser }) => execute(async () => deps.listProfiles(browser)),
+    async () =>
+      result({
+        version,
+        allowedOrigins: [...policy.allowedOrigins].sort(),
+        cookieValuesEnabled: policy.allowCookieValues,
+        allowedMethods: policy.allowUnsafeMethods
+          ? ["GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"]
+          : ["GET", "HEAD"],
+        network: {
+          proxyConfigured: Boolean(
+            process.env.HTTPS_PROXY ||
+              process.env.https_proxy ||
+              process.env.HTTP_PROXY ||
+              process.env.http_proxy,
+          ),
+          nodeUseEnvProxy: process.env.NODE_USE_ENV_PROXY === "1",
+        },
+        nextStep: policy.allowedOrigins.size
+          ? "Call list_profiles with a URL on an enabled origin to find a profile containing applicable cookies."
+          : "Add --allow-origin https://your-site.example to the MCP server arguments and restart the server to enable cookie queries and requests.",
+      }),
+  );
+  server.registerTool(
+    "list_profiles",
+    {
+      description:
+        "List local browser profiles. Supply a URL on an enabled origin to count applicable cookies in each profile and find the right account in one call. Cookie values are never returned. Zero matches can also indicate an inaccessible store. Safari uses its default store; query it directly.",
+      inputSchema: {
+        browser: browser.optional(),
+        url: selection.url.optional(),
+        name: selection.name,
+        container: selection.container,
+      },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        openWorldHint: false,
+      },
+    },
+    async (input, extra) =>
+      execute(async () => {
+        if (input.url === undefined) {
+          if (input.name !== undefined || input.container !== undefined) {
+            throw new McpOperationError(
+              "Provide a URL to check cookies by name or container.",
+              "URL_REQUIRED",
+            );
+          }
+          return deps.listProfiles(input.browser);
+        }
+        const url = assertAllowedUrl(input.url, policy);
+        if (input.container !== undefined && input.browser !== "firefox") {
+          throw new McpOperationError(
+            "Select browser firefox when filtering by container.",
+            "FIREFOX_REQUIRED",
+          );
+        }
+        const discovered = deps.listProfiles(input.browser);
+        const profiles = [];
+        for (const profile of discovered.profiles) {
+          extra.signal.throwIfAborted();
+          try {
+            const cookies = await selectCookies(
+              url,
+              {
+                browser: profile.browser,
+                profile: profile.name,
+                ...(input.name !== undefined && { name: input.name }),
+                ...(input.container !== undefined && {
+                  container: input.container,
+                }),
+              },
+              deps.readCookies,
+            );
+            profiles.push({ ...profile, cookieCount: cookies.length });
+          } catch (error) {
+            profiles.push({
+              ...profile,
+              cookieCount: null,
+              error: operationError(error),
+            });
+          }
+        }
+        extra.signal.throwIfAborted();
+        return {
+          ...discovered,
+          profiles,
+          matchingProfiles: profiles.filter(
+            (p) => p.cookieCount !== null && p.cookieCount > 0,
+          ).length,
+          note: `${discovered.note} Counts include only applicable cookies; zero can also mean an inaccessible store. Pass a returned profile name as profile when querying or fetching.`,
+        };
+      }),
   );
 
   server.registerTool(

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -67,6 +67,18 @@ function result(output: Record<string, unknown>) {
 }
 
 function operationError(error: unknown) {
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "name" in error &&
+    error.name === "AbortError"
+  ) {
+    return {
+      code: "REQUEST_ABORTED",
+      message:
+        "The call was cancelled. An in-progress browser read may need to finish before cancellation is observed.",
+    };
+  }
   return error instanceof McpOperationError
     ? { code: error.code, message: error.message }
     : {
@@ -155,7 +167,7 @@ export function createMcpServer(
     "list_profiles",
     {
       description:
-        "List local browser profiles. Supply a URL on an enabled origin to count applicable cookies in each profile and find the right account in one call. Cookie values are never returned. Zero matches can also indicate an inaccessible store. Safari uses its default store; query it directly.",
+        "List local browser profiles. Supply a URL on an enabled origin to count applicable cookies in each profile and find the right account in one call. Specify browser to limit reads; omitting it with a URL reads and decrypts cookies across all discovered browsers. Reads run sequentially, have no per-profile timeout, and observe cancellation between reads. Cookie values are never returned. Zero matches can also indicate an inaccessible store. Safari uses its default store; query it directly.",
       inputSchema: {
         browser: browser.optional(),
         url: selection.url.optional(),

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -28,6 +28,14 @@ const selection = {
     .describe("Exact destination URL, including path, on an enabled origin."),
   browser,
   profile: z.string().min(1).max(256).optional(),
+  profileDirectory: z
+    .string()
+    .min(1)
+    .max(8192)
+    .optional()
+    .describe(
+      "Exact Firefox profileDirectory returned by list_profiles; takes precedence over profile names.",
+    ),
   container: z
     .union([z.string().min(1).max(256), z.number().int().nonnegative()])
     .optional()
@@ -106,7 +114,7 @@ export function createMcpServer(
     { name: "get-cookie", version },
     {
       instructions:
-        "Use get_status to inspect enabled origins. Call list_profiles with the destination URL and optional cookie name to find a matching profile in one call, then pass its browser and name as the profile to query_cookies or authenticated_fetch. Authenticated fetch uses cookies directly; reading their values is unnecessary.",
+        "Use get_status to inspect enabled origins. Call list_profiles with the destination URL and optional cookie name to find a matching profile in one call, then pass its browser and name as profile to query_cookies or authenticated_fetch. For Firefox, also pass the returned profileDirectory to select that exact store. Authenticated fetch uses cookies directly; reading their values is unnecessary.",
     },
   );
   server.registerTool(
@@ -188,6 +196,9 @@ export function createMcpServer(
               {
                 browser: profile.browser,
                 profile: profile.name,
+                ...(profile.profileDirectory !== undefined && {
+                  profileDirectory: profile.profileDirectory,
+                }),
                 ...(input.name !== undefined && { name: input.name }),
                 ...(input.container !== undefined && {
                   container: input.container,
@@ -211,7 +222,7 @@ export function createMcpServer(
           matchingProfiles: profiles.filter(
             (p) => p.cookieCount !== null && p.cookieCount > 0,
           ).length,
-          note: `${discovered.note} Counts include only applicable cookies; zero can also mean an inaccessible store. Pass a returned profile name as profile when querying or fetching.`,
+          note: `${discovered.note} Counts include only applicable cookies; zero can also mean an inaccessible store. Pass the returned name as profile and, for Firefox, profileDirectory when querying or fetching.`,
         };
       }),
   );


### PR DESCRIPTION
## Summary

MCP clients previously had to query profiles individually to find a site's session, and request failures hid the transport cause. `list_profiles` now accepts a destination URL and optional cookie name/container, returns applicable cookie counts per profile, and continues when a profile cannot be read. `get_status` exposes enabled origins, HTTP methods and proxy configuration.

Errors now include structured codes and actionable origin, proxy, DNS and TLS guidance. The MCP guide documents installation and the profile-to-request workflow. Existing discovery calls remain compatible, and origin, method and cookie-value defaults are unchanged.

## Validation

- `pnpm run validate`: 91 suites passed; 721 tests passed, 4 existing skips.
- 28 MCP tests, including client/server integration, profile selection and transport-error regressions.
- `pnpm run build` and `pnpm run docs` passed.
- Live stdio trial: status → matching-profile discovery → authenticated GET completed in three tool calls, returning HTTP 200 without redirect. Cookie values and response content were not logged.

The local build must be rebuilt and the MCP server reconnected to pick up the new tool and schemas.
