### PR TITLE
fix(linux): prioritize the cookie prefix encryption key

### DIFF
--- a/src/core/browsers/chrome/__tests__/decrypt.test.ts
+++ b/src/core/browsers/chrome/__tests__/decrypt.test.ts
@@ -86,11 +86,19 @@ describe("decrypt", () => {
         expect(await decrypt(blob, "wrong-keyring")).toBe(value);
       },
     );
-    it("accepts the supplied key before basic and empty passwords", async () => {
+    it("prefers the v10 basic key when a stale key also produces valid text", async () => {
+      // Real CBC collision: this stale password passes padding and UTF-8 validation.
+      // The ciphertext was encrypted with peanuts and contains the value "cookie".
+      const blob = Buffer.from("7631301bea037fd02eda9472a6491e3836843f", "hex");
+      await expect(decrypt(blob, "stale-key-512902", 23)).resolves.toBe(
+        "cookie",
+      );
+    });
+    it("accepts the v11 keyring key and the v10 basic key", async () => {
       const value = "retain'whole-value";
       expect(
         await decrypt(
-          buildCbcBlob(Buffer.from(value), "keyring", 1),
+          buildCbcBlob(Buffer.from(value), "keyring", 1, "v11"),
           "keyring",
         ),
       ).toBe(value);

--- a/src/core/browsers/chrome/decrypt.ts
+++ b/src/core/browsers/chrome/decrypt.ts
@@ -197,7 +197,12 @@ async function decryptLinuxCookie(
         .update(domain ?? "")
         .digest()
     : null;
-  for (const candidate of new Set([password, "peanuts", ""])) {
+  // Linux v10 selects basic storage; v11 selects the desktop keyring.
+  // Older databases lack a domain hash, so padding/text alone cannot establish
+  // which key was intended. Prefer the format's key before compatibility fallbacks.
+  const candidates =
+    prefix === "v10" ? ["peanuts", password, ""] : [password, "peanuts", ""];
+  for (const candidate of new Set(candidates)) {
     const key = await deriveKey(candidate, 1);
     try {
       const decipher = createDecipheriv(


### PR DESCRIPTION
Linux v10 cookies use the basic-storage key. A stale keyring secret can nevertheless produce valid padding and UTF-8, causing older cookies without a domain hash to return corrupted text. Prefer the basic key for v10 and the keyring key for v11 before trying compatibility fallbacks.

The regression uses a real AES-CBC ciphertext and a deterministic stale-key collision: it failed with corrupted text before this change and now returns the original cookie value. Full validation passes: 816 tests across 92 suites, four existing skips, type checking, lint, formatting and documentation links. Library/CLI builds and the rebuilt MCP stdio smoke test also pass.

Follow-up to the [late review finding on #611](https://github.com/mherod/get-cookie/pull/611#discussion_r3960477429). Refs #563.
